### PR TITLE
*DO NOT MERGE* PLANNER-900: Added basic REST API for continuous planning

### DIFF
--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/OptaShiftRosteringEntryPoint.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/OptaShiftRosteringEntryPoint.java
@@ -32,7 +32,12 @@ public class OptaShiftRosteringEntryPoint {
         GWT.setUncaughtExceptionHandler(new
                 GWT.UncaughtExceptionHandler() {
                 public void onUncaughtException(Throwable e) {
-                  ErrorPopup.show(e.getMessage());
+                    StringBuilder out = new StringBuilder(e.getMessage());
+                    out.append("\n\n");
+                    for (StackTraceElement element : e.getStackTrace()) {
+                        out.append(element.toString());
+                    }
+                  ErrorPopup.show(out.toString());
               }
           });
     }

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/gwtjackson/DurationJsonDeserializer.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/gwtjackson/DurationJsonDeserializer.java
@@ -1,0 +1,20 @@
+package org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson;
+
+import java.time.Duration;
+
+import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
+import com.github.nmorel.gwtjackson.client.JsonDeserializer;
+import com.github.nmorel.gwtjackson.client.JsonDeserializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonReader;
+
+public class DurationJsonDeserializer extends JsonDeserializer<Duration> {
+
+    @Override
+    protected Duration doDeserialize(JsonReader reader, JsonDeserializationContext ctx, JsonDeserializerParameters params) {
+        String text = reader.nextString();
+        // TODO the super source of DateTimeFormatter is broken
+//        return LocalDateTime.parse(text, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        return Duration.parse(text);
+    }
+
+}

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/gwtjackson/DurationJsonSerializer.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/gwtjackson/DurationJsonSerializer.java
@@ -1,0 +1,19 @@
+package org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson;
+
+import java.time.Duration;
+
+import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
+import com.github.nmorel.gwtjackson.client.JsonSerializer;
+import com.github.nmorel.gwtjackson.client.JsonSerializerParameters;
+import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+
+public class DurationJsonSerializer extends JsonSerializer<Duration> {
+
+    @Override
+    protected void doSerialize(JsonWriter writer, Duration value, JsonSerializationContext ctx, JsonSerializerParameters params) {
+        // TODO the super source of DateTimeFormatter is broken
+        // writer.value(value.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        writer.value(value.toString());
+    }
+
+}

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/rebind/OptaShiftRosteringGwtJacksonConfiguration.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/rebind/OptaShiftRosteringGwtJacksonConfiguration.java
@@ -1,10 +1,13 @@
 package org.optaplanner.openshift.employeerostering.gwtui.rebind;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.github.nmorel.gwtjackson.client.AbstractConfiguration;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.DurationJsonDeserializer;
+import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.DurationJsonSerializer;
 import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.HardSoftScoreJsonDeserializer;
 import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.HardSoftScoreJsonSerializer;
 import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.LocalDateJsonDeserializer;
@@ -16,6 +19,7 @@ public class OptaShiftRosteringGwtJacksonConfiguration extends AbstractConfigura
 
     @Override
     protected void configure() {
+        type(Duration.class).serializer(DurationJsonSerializer.class).deserializer(DurationJsonDeserializer.class);
         type(LocalDate.class).serializer(LocalDateJsonSerializer.class).deserializer(LocalDateJsonDeserializer.class);
         type(LocalDateTime.class).serializer(LocalDateTimeJsonSerializer.class).deserializer(LocalDateTimeJsonDeserializer.class);
         type(HardSoftScore.class).serializer(HardSoftScoreJsonSerializer.class).deserializer(HardSoftScoreJsonDeserializer.class);

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/roster/EmployeeRosterViewPanel.html
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/roster/EmployeeRosterViewPanel.html
@@ -3,6 +3,9 @@
     <button id="solveButton" class="btn btn-success" aria-label="Solve">
       <span class="glyphicon glyphicon-play" aria-hidden="true" data-i18n-key="AbstractRosterViewPanel.solve"/> Solve
     </button>
+    <button id="planNextPeriod" class="btn btn-success" aria-label="Plan">
+      <span class="glyphicon glyphicon-play" aria-hidden="true"/> Plan
+    </button>
     <button id="refreshButton" class="btn btn-default" aria-label="Refresh">
       <span class="glyphicon glyphicon-refresh" aria-hidden="true" data-i18n-key="General.refresh"/> Refresh
     </button>

--- a/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/shift/ShiftRestServiceImpl.java
+++ b/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/shift/ShiftRestServiceImpl.java
@@ -16,8 +16,11 @@
 
 package org.optaplanner.openshift.employeerostering.server.shift;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -30,6 +33,7 @@ import org.optaplanner.openshift.employeerostering.shared.employee.EmployeeAvail
 import org.optaplanner.openshift.employeerostering.shared.shift.Shift;
 import org.optaplanner.openshift.employeerostering.shared.shift.ShiftRestService;
 import org.optaplanner.openshift.employeerostering.shared.shift.view.ShiftView;
+import org.optaplanner.openshift.employeerostering.shared.skill.Skill;
 import org.optaplanner.openshift.employeerostering.shared.spot.Spot;
 import org.optaplanner.openshift.employeerostering.shared.spot.SpotRestService;
 import org.optaplanner.openshift.employeerostering.shared.timeslot.TimeSlot;
@@ -38,7 +42,17 @@ public class ShiftRestServiceImpl extends AbstractRestServiceImpl implements Shi
 
     @PersistenceContext
     private EntityManager entityManager;
-
+    
+    @Override
+    public List<ShiftView> getShifts(Integer tenantId) {
+        List<Shift> shifts = entityManager.createNamedQuery("Shift.findAll", Shift.class)
+                .setParameter("tenantId", tenantId)
+                .getResultList();
+        return shifts.stream()
+                .map((s) -> new ShiftView(s))
+                .collect(Collectors.toList());
+    }
+    
     @Override
     @Transactional
     public ShiftView getShift(Integer tenantId, Long id) {

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/roster/RosterRestService.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/roster/RosterRestService.java
@@ -43,6 +43,11 @@ public interface RosterRestService {
     @POST
     @Path("/solve")
     void solveRoster(@PathParam("tenantId") Integer tenantId);
+    
+    @POST
+    @Path("/plan")
+    List<Long> planUntil(@PathParam("tenantId") Integer tenantId, @QueryParam("baseDate") String baseDateString,
+            @QueryParam("targetDate") String targetDateString, @QueryParam("duration") String durationString);
 
     // Not a REST method
     Roster buildRoster(Integer tenantId);

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/ShiftRestService.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/ShiftRestService.java
@@ -1,5 +1,7 @@
 package org.optaplanner.openshift.employeerostering.shared.shift;
 
+import java.util.List;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -19,7 +21,13 @@ import org.optaplanner.openshift.employeerostering.shared.shift.view.ShiftView;
 @Consumes(MediaType.APPLICATION_JSON)
 @GenRestBuilder
 public interface ShiftRestService {
-
+    /**
+     * @return never null, List<ShiftView>
+     */
+    @GET
+    @Path("/")
+    List<ShiftView> getShifts(@PathParam("tenantId") Integer tenantId);
+    
     /**
      * @param id never null
      * @return never null, the id


### PR DESCRIPTION
@ge0ffrey I added a basic REST API for simple continuous planning: Added method planUntil(tenantId, baseDate, targetDate, duration), which takes shifts between baseDate and (baseDate + duration), and copies them, except time slots are changed so if a time slot starts at (baseDate + x), it starts at (targetDate + x) instead. Added a simple button to the employeeRosterView to copy all shifts to the last end date.