### PR TITLE
PLANNER-918: Removed the openshift template limitations

### DIFF
--- a/openshift/templates/optashift-employee-rostering-template.yaml
+++ b/openshift/templates/optashift-employee-rostering-template.yaml
@@ -41,13 +41,6 @@ objects:
     - type: ConfigChange
     - imageChange: {}
       type: ImageChange
-    resources:
-      limits:
-        cpu: "1"
-        memory: 1400Mi
-      requests:
-        cpu: "1"
-        memory: 1400Mi
     runPolicy: Serial
 - apiVersion: v1
   kind: DeploymentConfig


### PR DESCRIPTION
I still need to edit the README.doc; I don't know what instructions to put for it. However, I got it running on my local OpenShift instance. 