### PR TITLE
PLANNER-944: Single-Click to change employee avaliability, Shift-Click for more complex edits

### DIFF
--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/Calendar.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/Calendar.java
@@ -1,29 +1,22 @@
 package org.optaplanner.openshift.employeerostering.gwtui.client.calendar;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import elemental2.dom.MouseEvent;
-import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.ui.HTML;
-import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.optaplanner.openshift.employeerostering.gwtui.client.calendar.twodayview.TwoDayViewPresenter;
 import org.optaplanner.openshift.employeerostering.gwtui.client.common.ConstantFetchable;
+import org.optaplanner.openshift.employeerostering.gwtui.client.common.TimeoutRestCaller;
 import org.optaplanner.openshift.employeerostering.gwtui.client.interfaces.DataProvider;
 import org.optaplanner.openshift.employeerostering.gwtui.client.interfaces.Fetchable;
 import org.optaplanner.openshift.employeerostering.gwtui.client.interfaces.HasTimeslot;
-import org.optaplanner.openshift.employeerostering.gwtui.client.popups.ErrorPopup;
 
 public class Calendar<G extends HasTitle, I extends HasTimeslot<G>> {
 
@@ -34,12 +27,10 @@ public class Calendar<G extends HasTitle, I extends HasTimeslot<G>> {
     Fetchable<Collection<I>> dataProvider;
     Fetchable<List<G>> groupProvider;
     DataProvider<G, I> instanceCreator;
-    Timer timer;
     boolean didTenantChange;
 
     private Calendar(Integer tenantId, Fetchable<Collection<I>> dataProvider, Fetchable<List<G>> groupProvider,
-            DataProvider<G,
-                    I> instanceCreator, SyncBeanManager beanManager) {
+                     DataProvider<G, I> instanceCreator, SyncBeanManager beanManager) {
         this.beanManager = beanManager;
         this.tenantId = tenantId;
 
@@ -49,14 +40,6 @@ public class Calendar<G extends HasTitle, I extends HasTimeslot<G>> {
         setInstanceCreator(instanceCreator);
         setGroupProvider(groupProvider);
         setDataProvider(dataProvider);
-
-        timer = new Timer() {
-
-            @Override
-            public void run() {
-                forceUpdate();
-            }
-        };
 
         refresh();
 
@@ -85,8 +68,7 @@ public class Calendar<G extends HasTitle, I extends HasTimeslot<G>> {
         view.draw();
     }
 
-    public void refresh() {
-    }
+    public void refresh() {}
 
     public void forceUpdate() {
         dataProvider.fetchData(() -> draw());
@@ -94,7 +76,7 @@ public class Calendar<G extends HasTitle, I extends HasTimeslot<G>> {
 
     public void setDate(LocalDateTime date) {
         view.setDate(date);
-        timer.schedule(1000);
+        TimeoutRestCaller.call(this, () -> forceUpdate());
     }
 
     public LocalDateTime getViewStartDate() {
@@ -294,10 +276,10 @@ public class Calendar<G extends HasTitle, I extends HasTimeslot<G>> {
         public Calendar<G, T> asTwoDayView(TimeRowDrawableProvider<G, T, D> drawableProvider) {
             if (null != beanManager) {
                 Calendar<G, T> calendar = new Calendar<>(tenantId,
-                        dataProvider,
-                        groupProvider, instanceCreator, beanManager);
+                                                         dataProvider,
+                                                         groupProvider, instanceCreator, beanManager);
                 TwoDayViewPresenter<G, T, D> view = new TwoDayViewPresenter<G, T, D>(calendar,
-                        drawableProvider, dateDisplay, translator);
+                                                                                     drawableProvider, dateDisplay, translator);
                 calendar.setView(view);
 
                 if (null != startAt) {
@@ -309,8 +291,7 @@ public class Calendar<G extends HasTitle, I extends HasTimeslot<G>> {
                 calendar.setViewSize(container.getOffsetWidth(), container.getOffsetHeight());
                 return calendar;
             } else {
-                throw new IllegalStateException("You must set all of "
-                        + "(beanManager) before calling this method.");
+                throw new IllegalStateException("You must set all of " + "(beanManager) before calling this method.");
             }
         }
 

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/canvas/ColorUtils.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/canvas/ColorUtils.java
@@ -1,14 +1,12 @@
 package org.optaplanner.openshift.employeerostering.gwtui.client.canvas;
 
-import org.optaplanner.openshift.employeerostering.gwtui.client.popups.ErrorPopup;
-
 public class ColorUtils {
 
     private static final double GOLDEN_RATIO = (1.0 + Math.sqrt(5)) / 2.0;
 
     // TODO: Make a proper brighten method
     public static String brighten(String color) {
-        return blend(color, "#E0E0E0", 0.5);
+        return blend(color, "#E0E0E0", 0.0);
     }
 
     public static String blend(String color1, String color2, double rgb2amount) {
@@ -17,8 +15,8 @@ public class ColorUtils {
         double rgb1amount = 1 - rgb2amount;
 
         return getHexFromRGB(new int[]{(int) Math.round(rgb1[0] * rgb1amount + rgb2[0] * rgb2amount),
-                (int) Math.round(rgb1[1] * rgb1amount + rgb2[1] * rgb2amount),
-                (int) Math.round(rgb1[2] * rgb1amount + rgb2[2] * rgb2amount)});
+                                       (int) Math.round(rgb1[1] * rgb1amount + rgb2[1] * rgb2amount),
+                                       (int) Math.round(rgb1[2] * rgb1amount + rgb2[2] * rgb2amount)});
     }
 
     public static String getColor(int num) {
@@ -73,8 +71,8 @@ public class ColorUtils {
     public static int[] getRGBFromRGB(String rgb) {
         String[] values = rgb.substring(4).split(",");
         return new int[]{Integer.parseInt(values[0].trim()),
-                Integer.parseInt(values[1].trim()),
-                Integer.parseInt(values[2].substring(0, values[2].indexOf(')')).trim())};
+                         Integer.parseInt(values[1].trim()),
+                         Integer.parseInt(values[2].substring(0, values[2].indexOf(')')).trim())};
     }
 
     public static String getHexFromRGB(int[] rgb) {

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/common/TimeoutRestCaller.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/common/TimeoutRestCaller.java
@@ -1,0 +1,50 @@
+package org.optaplanner.openshift.employeerostering.gwtui.client.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwt.user.client.Timer;
+
+public class TimeoutRestCaller {
+
+    private static Map<Object, TimeoutRestCaller> callerMap = new HashMap<>();
+    private Callee callee;
+    private Timer timer;
+
+    private TimeoutRestCaller(Callee callee, Object obj) {
+        this.callee = callee;
+        timer = new Timer() {
+
+            @Override
+            public void run() {
+                doCall(obj);
+            }
+        };
+    }
+
+    public static void call(Object obj, Callee callee) {
+        call(obj, callee, 1000);
+    }
+
+    public static void call(Object obj, Callee callee, int delayMilliSec) {
+        TimeoutRestCaller caller = callerMap.get(obj);
+        if (null == caller) {
+            caller = new TimeoutRestCaller(callee, obj);
+            callerMap.put(obj, caller);
+        } else {
+            caller.callee = callee;
+        }
+        caller.timer.schedule(delayMilliSec);
+    }
+
+    private static void doCall(Object obj) {
+        TimeoutRestCaller caller = callerMap.get(obj);
+        callerMap.remove(obj);
+        caller.callee.call();
+    }
+
+    public interface Callee {
+
+        void call();
+    }
+}


### PR DESCRIPTION
@ge0ffrey Let me know what you think; I modified it so a single click without shift key pressed down cycles employee availability (red -> yellow -> green -> gray -> red -> ...). If you single click with shift key pressed down, you get the original popup. I could put an embedded widget that you can click, but that can pose an issue for users with smaller screens.