### PR TITLE
PLANNER-943: Allow users to specify a default employee for a shift

### DIFF
--- a/optashift-employee-rostering-benchmark/src/main/java/org/optaplanner/openshift/employeerostering/benchmark/OptaShiftEmployeeRosteringBenchmarkApp.java
+++ b/optashift-employee-rostering-benchmark/src/main/java/org/optaplanner/openshift/employeerostering/benchmark/OptaShiftEmployeeRosteringBenchmarkApp.java
@@ -27,13 +27,14 @@ public class OptaShiftEmployeeRosteringBenchmarkApp {
     }
 
     private static List<Roster> generateRosters() {
-        EntityManagerFactory entityManagerFactory = Persistence.createEntityManagerFactory("optashift-employee-rostering-persistence-unit");
+        EntityManagerFactory entityManagerFactory = Persistence.createEntityManagerFactory(
+                "optashift-employee-rostering-persistence-unit");
         EntityManager entityManager = entityManagerFactory.createEntityManager();
         RosterGenerator rosterGenerator = new RosterGenerator(entityManager);
 
         List<Roster> rosterList = new ArrayList<>();
-        rosterList.add(rosterGenerator.generateRoster(10, 7, false));
-        rosterList.add(rosterGenerator.generateRoster(80, (28 * 4), false));
+        rosterList.add(rosterGenerator.generateRoster(10, 7, false, false));
+        rosterList.add(rosterGenerator.generateRoster(80, (28 * 4), false, true));
 
         entityManager.close();
         entityManagerFactory.close();

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/ShiftData.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/ShiftData.java
@@ -6,7 +6,9 @@ import java.util.Arrays;
 import org.optaplanner.openshift.employeerostering.gwtui.client.interfaces.HasTimeslot;
 import org.optaplanner.openshift.employeerostering.gwtui.client.spot.SpotData;
 import org.optaplanner.openshift.employeerostering.gwtui.client.spot.SpotId;
+import org.optaplanner.openshift.employeerostering.shared.employee.Employee;
 import org.optaplanner.openshift.employeerostering.shared.lang.tokens.IdOrGroup;
+import org.optaplanner.openshift.employeerostering.shared.lang.tokens.OptionalEmployee;
 import org.optaplanner.openshift.employeerostering.shared.lang.tokens.ShiftInfo;
 import org.optaplanner.openshift.employeerostering.shared.shift.Shift;
 
@@ -16,6 +18,8 @@ public class ShiftData extends ShiftInfo implements HasTimeslot<SpotId> {
 
     public ShiftData(SpotData shift) {
         super();
+        super.setRotationEmployeeList(Arrays.asList(new OptionalEmployee(shift.getShift().getTenantId(), shift
+                .getShift().getRotationEmployee())));
         this.setStartTime(shift.getStartTime());
         this.setEndTime(shift.getEndTime());
         this.setSpotList(Arrays.asList(new IdOrGroup(shift.getSpot().getTenantId(), false, shift.getSpot().getId())));
@@ -52,6 +56,15 @@ public class ShiftData extends ShiftInfo implements HasTimeslot<SpotId> {
 
     public Shift getShift() {
         return shift.getShift();
+    }
+
+    public Employee getRotationEmployee() {
+        return shift.getShift().getRotationEmployee();
+    }
+
+    public void setRotationEmployee(Employee rotationEmployee) {
+        super.getRotationEmployeeList().set(0, new OptionalEmployee(shift.getShift().getTenantId(), rotationEmployee));
+        shift.getShift().setRotationEmployee(rotationEmployee);
     }
 
     @Override

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/TemplateShiftEditForm.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/TemplateShiftEditForm.java
@@ -1,0 +1,122 @@
+package org.optaplanner.openshift.employeerostering.gwtui.client.calendar;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.gwt.dom.client.HeadingElement;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.user.client.ui.Button;
+import org.gwtbootstrap3.client.ui.CheckBox;
+import org.gwtbootstrap3.client.ui.ListBox;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.optaplanner.openshift.employeerostering.gwtui.client.common.FailureShownRestCallback;
+import org.optaplanner.openshift.employeerostering.gwtui.client.popups.FormPopup;
+import org.optaplanner.openshift.employeerostering.shared.employee.Employee;
+import org.optaplanner.openshift.employeerostering.shared.employee.EmployeeRestServiceBuilder;
+
+@Templated
+public class TemplateShiftEditForm implements IsElement {
+
+    @Inject
+    @DataField
+    private CheckBox hasPreferredEmployee;
+
+    @Inject
+    @DataField
+    private ListBox preferredEmployee;
+
+    @Inject
+    @DataField
+    private Button saveButton;
+
+    @Inject
+    @DataField
+    private Button cancelButton;
+
+    @Inject
+    @DataField
+    private Button closeButton;
+
+    @Inject
+    @DataField
+    private @Named(value = "h3") HeadingElement title;
+
+    @Inject
+    private TranslationService CONSTANTS;
+
+    private static ShiftDrawable myShift;
+
+    private FormPopup popup;
+    private ShiftDrawable shift;
+    private List<Employee> employeeList;
+
+    public TemplateShiftEditForm() {
+        shift = myShift;
+    }
+
+    public static TemplateShiftEditForm create(SyncBeanManager beanManager, ShiftDrawable shift) {
+        myShift = shift;
+        return beanManager.lookupBean(TemplateShiftEditForm.class).newInstance();
+    }
+
+    @PostConstruct
+    protected void initWidget() {
+        hasPreferredEmployee.setValue(shift.getData().getRotationEmployee() != null);
+        title.setInnerSafeHtml(new SafeHtmlBuilder().appendEscaped(shift.getData().getShift().getSpot().getName())
+                                                    .appendEscaped(" - ")
+                                                    .appendEscaped(shift.getData().getStartTime().toLocalTime().toString())
+                                                    .appendEscaped("-")
+                                                    .appendEscaped(shift.getData().getEndTime().toLocalTime().toString())
+                                                    .toSafeHtml());
+        TemplateShiftEditForm form = this;
+        EmployeeRestServiceBuilder.getEmployeeList(shift.getData().getShift().getTenantId(),
+                                                   new FailureShownRestCallback<List<Employee>>() {
+
+                                                       @Override
+                                                       public void onSuccess(List<Employee> tenantEmployeeList) {
+                                                           employeeList = tenantEmployeeList;
+                                                           employeeList.forEach((e) -> preferredEmployee.addItem(e.getName()));
+                                                           if (!hasPreferredEmployee.getValue()) {
+                                                               preferredEmployee.setEnabled(false);
+                                                           } else {
+                                                               preferredEmployee.setSelectedIndex(employeeList.indexOf(shift.getData()
+                                                                                                                            .getRotationEmployee()));
+                                                           }
+                                                           hasPreferredEmployee.addValueChangeHandler((v) -> preferredEmployee.setEnabled(v.getValue()));
+
+                                                           popup = FormPopup.getFormPopup(form);
+                                                           popup.center();
+                                                       }
+                                                   });
+    }
+
+    @EventHandler("cancelButton")
+    public void cancel(ClickEvent e) {
+        popup.hide();
+    }
+
+    @EventHandler("closeButton")
+    public void close(ClickEvent e) {
+        popup.hide();
+    }
+
+    @EventHandler("saveButton")
+    public void save(ClickEvent click) {
+        if (hasPreferredEmployee.getValue()) {
+            Employee employee = employeeList.stream().filter((e) -> e.getName().equals(preferredEmployee.getSelectedValue())).findFirst().get();
+            shift.getData().setRotationEmployee(employee);
+        } else {
+            shift.getData().setRotationEmployee(null);
+        }
+        popup.hide();
+    }
+}

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/twodayview/TwoDayViewPresenter.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/twodayview/TwoDayViewPresenter.java
@@ -242,7 +242,7 @@ public class TwoDayViewPresenter<G extends HasTitle, I extends HasTimeslot<G>, D
         view.updateScrollBars();
         view.setViewSize(state.getScreenWidth(), state.getScreenHeight());
 
-        if (!getState().getGroupPosMap().isEmpty()) {
+        if (getState().getGroupPosMap().keySet().containsAll(getGroupList())) {
             view.draw();
         }
     }

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/spot/SpotDataFetchable.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/spot/SpotDataFetchable.java
@@ -82,7 +82,8 @@ public class SpotDataFetchable implements Fetchable<Collection<SpotData>> {
                                                     .getId())) {
                                         timeSlotIdToSpotIdToShiftViewListMap.get(timeslot.getId()).get(spot.getId())
                                                 .stream().forEach((sv) -> {
-                                                    Shift shift = new Shift(sv, spot, timeslot);
+                                                    Shift shift = new Shift(sv, spot, timeslot, employeeMap.get(sv
+                                                            .getRotationEmployeeId()));
                                                     shift.setEmployee(employeeMap.get(sv.getEmployeeId()));
                                                     out.add(new SpotData(shift));
                                                 });
@@ -128,7 +129,8 @@ public class SpotDataFetchable implements Fetchable<Collection<SpotData>> {
                                                     timeSlotIdToSpotIdToShiftViewListMap.get(timeslot.getId()).get(spot
                                                             .getId())
                                                             .stream().forEach((sv) -> {
-                                                                Shift shift = new Shift(sv, spot, timeslot);
+                                                                Shift shift = new Shift(sv, spot, timeslot, employeeMap
+                                                                        .get(sv.getRotationEmployeeId()));
                                                                 shift.setEmployee(employeeMap.get(sv.getEmployeeId()));
                                                                 SpotData newShift = new SpotData(shift);
                                                                 calendar.updateShift(newShift);

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/tenant/TenantConfigurationEditor.java.orig
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/tenant/TenantConfigurationEditor.java.orig
@@ -19,7 +19,6 @@ import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.optaplanner.openshift.employeerostering.gwtui.client.common.FailureShownRestCallback;
 import org.optaplanner.openshift.employeerostering.gwtui.client.tenant.ConfigurationEditor.Views;
-import org.optaplanner.openshift.employeerostering.shared.tenant.Tenant;
 import org.optaplanner.openshift.employeerostering.shared.tenant.TenantRestServiceBuilder;
 
 @Templated
@@ -80,12 +79,23 @@ public class TenantConfigurationEditor implements IsElement {
         rotationEmployeeMatchWeightInput.setValidators(new DecimalMinValidator<Integer>(0));
     }
 
+<<<<<<< HEAD
     public void onAnyTenantEvent(@Observes TenantStore.TenantChange tenant) {
         weekStart.setSelectedIndex(tenantStore.getCurrentTenant().getConfiguration().getWeekStart().getValue() - 1);
         templateDuration.setSelectedIndex(templateDurationIndexBiMap.get(tenantStore.getCurrentTenant().getConfiguration()
                                                                                     .getTemplateDuration()));
         desiredWeightInput.setValue(tenantStore.getCurrentTenant().getConfiguration().getDesiredTimeSlotWeight());
         undesiredWeightInput.setValue(tenantStore.getCurrentTenant().getConfiguration().getUndesiredTimeSlotWeight());
+=======
+    public void onAnyTenantEvent(@Observes Tenant tenant) {
+        this.tenant = tenant;
+        weekStart.setSelectedIndex(tenant.getConfiguration().getWeekStart().getValue() - 1);
+        templateDuration.setSelectedIndex(templateDurationIndexBiMap.get(tenant.getConfiguration()
+                                                                             .getTemplateDuration()));
+        desiredWeightInput.setValue(tenant.getConfiguration().getDesiredTimeSlotWeight());
+        undesiredWeightInput.setValue(tenant.getConfiguration().getUndesiredTimeSlotWeight());
+        rotationEmployeeMatchWeightInput.setValue(tenant.getConfiguration().getRotationEmployeeMatchWeight());
+>>>>>>> PLANNER-943: Added support for assigning default employees to shifts
         refresh();
     }
 
@@ -97,17 +107,34 @@ public class TenantConfigurationEditor implements IsElement {
 
     @EventHandler("updateConfig")
     private void onUpdateConfigClick(ClickEvent e) {
+<<<<<<< HEAD
         tenantStore.getCurrentTenant().getConfiguration().setTemplateDuration(templateDurationIndexBiMap.inverse().get(templateDuration
-                                                                                                             .getSelectedIndex()));
+                                                                                                                                       .getSelectedIndex()));
         tenantStore.getCurrentTenant().getConfiguration().setWeekStart(DayOfWeek.valueOf(weekStart.getSelectedItemText()));
         tenantStore.getCurrentTenant().getConfiguration().setDesiredTimeSlotWeight(desiredWeightInput.getValue());
         tenantStore.getCurrentTenant().getConfiguration().setUndesiredTimeSlotWeight(undesiredWeightInput.getValue());
-        tenantStore.getCurrentTenant().getConfiguration().setRotationEmployeeMatchWeight(rotationEmployeeMatchWeightInput.getValue());
         TenantRestServiceBuilder.updateTenantConfiguration(tenantStore.getCurrentTenant().getConfiguration(),
                                                            FailureShownRestCallback.onSuccess(i -> {
                                                                tenantStore.updateTenant(i);
                                                                tenantStore.setCurrentTenant(i);
                                                            }));
+=======
+        tenant.getConfiguration().setTemplateDuration(templateDurationIndexBiMap.inverse().get(templateDuration
+                                                                                                             .getSelectedIndex()));
+        tenant.getConfiguration().setWeekStart(DayOfWeek.valueOf(weekStart.getSelectedItemText()));
+        tenant.getConfiguration().setDesiredTimeSlotWeight(desiredWeightInput.getValue());
+        tenant.getConfiguration().setUndesiredTimeSlotWeight(undesiredWeightInput.getValue());
+        tenant.getConfiguration().setRotationEmployeeMatchWeight(rotationEmployeeMatchWeightInput.getValue());
+        TenantRestServiceBuilder.updateTenantConfiguration(tenant.getConfiguration(),
+                                                           new FailureShownRestCallback<Tenant>() {
+
+                                                               @Override
+                                                               public void onSuccess(Tenant newConfig) {
+                                                                   tenant.setConfiguration(newConfig.getConfiguration());
+                                                                   tenantEvent.fire(newConfig);
+                                                               }
+                                                           });
+>>>>>>> PLANNER-943: Added support for assigning default employees to shifts
     }
 
     @EventHandler("templateEditorButton")

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/tenant/TenantTemplateFetchable.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/tenant/TenantTemplateFetchable.java
@@ -18,6 +18,7 @@ import org.optaplanner.openshift.employeerostering.shared.shift.Shift;
 import org.optaplanner.openshift.employeerostering.shared.shift.ShiftRestServiceBuilder;
 import org.optaplanner.openshift.employeerostering.shared.spot.Spot;
 import org.optaplanner.openshift.employeerostering.shared.spot.SpotGroup;
+import org.optaplanner.openshift.employeerostering.shared.spot.SpotRestServiceBuilder;
 import org.optaplanner.openshift.employeerostering.shared.timeslot.TimeSlot;
 import org.optaplanner.openshift.employeerostering.shared.spot.SpotRestServiceBuilder;
 
@@ -55,6 +56,7 @@ public class TenantTemplateFetchable implements Fetchable<Collection<ShiftData>>
                                             id = 0L;
                                             List<ShiftData> out = new ArrayList<>();
                                             for (ShiftInfo shift : template.getShiftList()) {
+                                                int i = 0;
                                                 for (IdOrGroup spotId : shift.getSpotList()) {
                                                     if (spotId.getIsGroup()) {
                                                         for (Spot spot : spotGroupList.stream().filter((g) -> g.getId()
@@ -66,6 +68,8 @@ public class TenantTemplateFetchable implements Fetchable<Collection<ShiftData>>
                                                                             shift
                                                                                     .getEndTime()));
                                                             newShift.setId(id);
+                                                            newShift.setRotationEmployee(shift.getRotationEmployeeList()
+                                                                    .get(i).getEmployee());
                                                             id++;
                                                             out.add(new ShiftData(new SpotData(newShift)));
                                                         }
@@ -76,10 +80,12 @@ public class TenantTemplateFetchable implements Fetchable<Collection<ShiftData>>
                                                                 spot, new TimeSlot(tenantId, shift.getStartTime(), shift
                                                                         .getEndTime()));
                                                         newShift.setId(id);
+                                                        newShift.setRotationEmployee(shift.getRotationEmployeeList()
+                                                                .get(i).getEmployee());
                                                         id++;
                                                         out.add(new ShiftData(new SpotData(newShift)));
                                                     }
-
+                                                    i++;
                                                 }
                                             }
                                             updatable.onUpdate(out);

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/TemplateShiftEditForm.html
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/calendar/TemplateShiftEditForm.html
@@ -1,0 +1,16 @@
+<div class="modal-content">
+	<div class="modal-header">
+		<button id="closeButton" type="button" class="close" data-dismiss="modal">&times;</button>
+		<h4 id="title" class="modal-title">Modal Header</h4>
+	</div>
+	<div class="modal-body">
+		<label for="hasPreferredEmployee">Has Preferred Employee</label>
+		<input type="checkbox" id="hasPreferredEmployee" />
+		<label for="preferredEmployee">Preferred Employee</label>
+		<select id="preferredEmployee"></select>
+	</div>
+	<div class="modal-footer">
+		<button id="cancelButton" type="button" class="btn btn-default">Close</button>
+		<button id="saveButton" type="button" class="btn btn-primary">Save</button>
+	</div>
+</div>

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/tenant/TenantConfigurationEditor.html
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/tenant/TenantConfigurationEditor.html
@@ -1,13 +1,18 @@
 <div>
    <form>
        <!-- TODO: i18n -->
+       <!-- TODO: Validation -->
        <div class="form-group">
            <label for="undesiredWeightInput">Undesired Time Slot Weight</label>
-           <input id="undesiredWeightInput" type="number" name="ticketNum" value="100" min="0" class="form-control">
+           <input id="undesiredWeightInput" type="number" name="ticketNum" value="100" min="0" max="999" class="form-control"/>
        </div>
        <div class="form-group">
            <label for="desiredWeightInput">Desired Time Slot Weight</label>
-           <input id="desiredWeightInput" type="number" name="ticketNum" value="10" min="0" class="form-control">
+           <input id="desiredWeightInput" type="number" name="ticketNum" value="10" min="0" max="999" class="form-control"/>
+       </div>
+       <div class="form-group">
+           <label for="rotationEmployeeMatchWeightInput">Match Rotation Employee Weight</label>
+           <input id="rotationEmployeeMatchWeightInput" type="number" name="ticketNum" value="1000" min="0" max="999" class="form-control"/>
        </div>
        Week Start<select id="weekStart"></select>
        Period<select id="templateDuration"></select>

--- a/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/lang/parser/ShiftFileParser.java
+++ b/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/lang/parser/ShiftFileParser.java
@@ -29,12 +29,15 @@ import org.optaplanner.openshift.employeerostering.shared.timeslot.TimeSlot;
 
 //CUP maven plugins seems out of date; the format file is simple enough to code by hand
 public class ShiftFileParser {
-    
-    public static ParserOut parse(Integer tenantId, List<Spot> spotList,
-            List<Employee> employeeList, Map<Long, List<Spot>> spotGroupMap,
-            Map<Long, List<Employee>> employeeGroupMap,
-            LocalDateTime start, LocalDateTime end,
-            ShiftTemplate template) throws ParserException {
+
+    public static ParserOut parse(Integer tenantId,
+                                  List<Spot> spots,
+                                  List<Employee> employees,
+                                  Map<Long, List<Spot>> spotGroupMap,
+                                  Map<Long, List<Employee>> employeeGroupMap,
+                                  LocalDateTime start,
+                                  LocalDateTime end,
+                                  ShiftTemplate template) throws ParserException {
         ParserState state = new ParserState();
         state.tenantId = tenantId;
         state.startDate = start;
@@ -56,14 +59,14 @@ public class ShiftFileParser {
                     break;
                 case WEEK_OF_START_DATE:
                     state.baseDate = start
-                            .minusDays(start.getDayOfWeek().getValue() - 1)
-                            .toLocalDate().atStartOfDay();
+                                          .minusDays(start.getDayOfWeek().getValue() - 1)
+                                          .toLocalDate().atStartOfDay();
                     state.endDate = end.plusDays(6 - end.getDayOfWeek().getValue());
                     break;
                 case WEEK_AFTER_START_DATE:
                     state.baseDate = start
-                            .minusDays(start.getDayOfWeek().getValue() - 1)
-                            .toLocalDate().atStartOfDay().plusWeeks(1);
+                                          .minusDays(start.getDayOfWeek().getValue() - 1)
+                                          .toLocalDate().atStartOfDay().plusWeeks(1);
                     state.endDate = end.plusDays(6 - (end.getDayOfWeek().getValue() - 1)).plusWeeks(1);
                     break;
                 default:
@@ -78,7 +81,7 @@ public class ShiftFileParser {
         } else {
             dateMode = null;
         }
-        
+
         if (null == dateMode) {
             String[] duration = template.getRepeatType().getValue().split(":");
             if (4 != duration.length) {
@@ -93,8 +96,7 @@ public class ShiftFileParser {
             state.repeatWeeks = 0;
             state.repeatMonths = 0;
             state.repeatYears = 0;
-        }
-        else {
+        } else {
             state.repeatDays = dateMode.daysUntilRepeat;
             state.repeatWeeks = dateMode.weeksUntilRepeat;
             state.repeatMonths = dateMode.monthsUntilRepeat;
@@ -102,77 +104,77 @@ public class ShiftFileParser {
         }
 
         state.universalExceptionList = template.getUniversalExceptionList().stream()
-                .map((e) -> {
-                    try {
-                        return DateMatcher.getDateMatcher(e);
-                    } catch (Exception bad) {
-                        return null;
-                    }
-                }).collect(Collectors.toList());
-        
+                                            .map((e) -> {
+                                                try {
+                                                    return DateMatcher.getDateMatcher(e);
+                                                } catch (Exception bad) {
+                                                    return null;
+                                                }
+                                            }).collect(Collectors.toList());
+
         if (state.universalExceptionList.contains(null)) {
             throw new ParserException("Badly formatted date exception string");
         }
 
         state.shiftOutputList = new ArrayList<>();
-        state.employeeAvailabilityOutputList = new ArrayList<>();
-        state.spotMap = spotList.stream()
-                .collect(Collectors.toMap(Spot::getId, Function.identity()));
-        state.employeeMap = employeeList.stream()
-                .collect(Collectors.toMap(Employee::getId, Function.identity()));
+        state.employeeAvailabityOutputList = new ArrayList<>();
+        state.spotMap = spots.stream()
+                             .collect(Collectors.toMap(Spot::getId, Function.identity()));
+        state.employeeMap = employees.stream()
+                                     .collect(Collectors.toMap(Employee::getId, Function.identity()));
         state.spotGroupMap = spotGroupMap;
         state.employeeGroupMap = employeeGroupMap;
-        
+
         addShiftsFrom(state, template.getShiftList());
         ParserOut out = new ParserOut();
         out.shiftOutputList = state.shiftOutputList;
-        out.employeeAvailabilityOutputList = state.employeeAvailabilityOutputList;
+        out.employeeAvailabilityOutputList = state.employeeAvailabityOutputList;
 
         return out;
     }
-    
-    private static void addShiftsFrom(ParserState state, List<ShiftInfo> shiftList)
-            throws ParserException {
-        for (ShiftInfo shiftInfo : shiftList) {
-            List<DateMatcher<ShiftInfo>> exceptions = (null != shiftInfo.getExceptionList()) ? shiftInfo.getExceptionList()
-                    .stream()
-                    .map((e) -> {
-                        try {
-                            return DateMatcher.getDateMatcher(e);
-                        } catch (Exception bad) {
-                            return null;
-                        }
-                    }).collect(Collectors.toList()) : Collections.emptyList();
+
+    private static void addShiftsFrom(ParserState state, List<ShiftInfo> shifts) throws ParserException {
+        for (ShiftInfo shiftInfo : shifts) {
+            List<DateMatcher<ShiftInfo>> exceptions = (null != shiftInfo.getExceptionList()) ? shiftInfo
+                    .getExceptionList()
+                                                                                                     .stream()
+                                                                                                     .map((e) -> {
+                                                                                                         try {
+                                                                                                             return DateMatcher.getDateMatcher(e);
+                                                                                                         } catch (Exception bad) {
+                                                                                                             return null;
+                                                                                                         }
+                                                                                                     }).collect(Collectors.toList()) : Collections.emptyList();
             if (exceptions.contains(null)) {
                 throw new ParserException("Badly formatted date exception string");
             }
             for (LocalDateTime startDate = state.baseDate.plus(Duration.between(LocalDateTime.ofEpochSecond(0, 0,
-                    ZoneOffset.UTC),
-                    shiftInfo.getStartTime())), endDate = state.baseDate.plus(Duration.between(LocalDateTime
-                            .ofEpochSecond(0, 0, ZoneOffset.UTC),
-                            shiftInfo.getEndTime()));
+                                                                                                            ZoneOffset.UTC),
+                                                                                shiftInfo.getStartTime())), endDate = state.baseDate.plus(Duration.between(LocalDateTime
+                                                                                                                                                                        .ofEpochSecond(0, 0, ZoneOffset.UTC),
+                                                                                                                                                           shiftInfo.getEndTime()));
                     //Cond
                     startDate.isBefore(state.endDate);
                     //Post
                     startDate = startDate.plusYears(state.repeatYears)
-                            .plusMonths(state.repeatMonths)
-                            .plusWeeks(state.repeatWeeks)
-                            .plusDays(state.repeatDays),
+                                         .plusMonths(state.repeatMonths)
+                                         .plusWeeks(state.repeatWeeks)
+                                         .plusDays(state.repeatDays),
 
                     endDate = endDate.plusYears(state.repeatYears)
-                            .plusMonths(state.repeatMonths)
-                            .plusWeeks(state.repeatWeeks)
-                            .plusDays(state.repeatDays)) {
+                                     .plusMonths(state.repeatMonths)
+                                     .plusWeeks(state.repeatWeeks)
+                                     .plusDays(state.repeatDays)) {
                 LocalDateTime clone = startDate;
                 Optional<DateMatcher<ShiftInfo>> shiftException = exceptions.stream().filter((dm) -> dm.test(clone))
-                        .findFirst();
+                                                                            .findFirst();
                 if (shiftException.isPresent()) {
                     DateMatcher<ShiftInfo> dateMatcher = shiftException.get();
                     if (null != dateMatcher.getReplacement()) {
                         long oldRepeatDays = state.repeatDays;
                         state.repeatDays = Duration.between(state.startDate, state.endDate).toDays() + 1;
                         addShiftsFrom(state, Arrays.asList(dateMatcher
-                                .getReplacement()));
+                                                                      .getReplacement()));
                         state.repeatDays = oldRepeatDays;
                     }
                 } else {
@@ -183,7 +185,7 @@ public class ShiftFileParser {
                             long oldRepeatDays = state.repeatDays;
                             state.repeatDays = Duration.between(state.startDate, state.endDate).toDays() + 1;
                             addShiftsFrom(state, Arrays.asList(dateMatcher
-                                    .getReplacement()));
+                                                                          .getReplacement()));
                             state.repeatDays = oldRepeatDays;
                         }
                     } else {
@@ -194,39 +196,43 @@ public class ShiftFileParser {
         }
     }
 
-    private static void addShift(ParserState state, ShiftInfo shiftInfo, LocalDateTime startDate, LocalDateTime endDate)
-            throws ParserException {
+    private static void addShift(ParserState state, ShiftInfo shiftInfo, LocalDateTime startDate, LocalDateTime endDate) throws ParserException {
         TimeSlot timeslot = new TimeSlot(state.tenantId, startDate, endDate);
+        int i = 0;
         for (IdOrGroup id : shiftInfo.getSpotList()) {
             if (id.getIsGroup()) {
                 for (Spot spot : state.spotGroupMap.get(id.getItemId())) {
-                    state.shiftOutputList.add(new Shift(state.tenantId, spot, timeslot));
+                    // Grouped spots cannot have a rotation employee, since it be impossible
+                    // to decide what spot get what employee
+                    state.shiftOutputList.add(new Shift(state.tenantId, spot, timeslot, null));
                 }
-            }
-            else {
+            } else {
                 Spot spot = state.spotMap.get(id.getItemId());
                 if (null == spot) {
                     throw new ParserException("spot is null! id: " + id.getItemId());
                 }
-                state.shiftOutputList.add(new Shift(state.tenantId, spot, timeslot));
+                state.shiftOutputList.add(new Shift(state.tenantId, spot, timeslot, shiftInfo.getRotationEmployeeList().get(i)
+                        .getEmployee()));
+                i++;
             }
         }
-        
+
         for (EmployeeTimeSlotInfo employeeInfo : shiftInfo.getEmployeeList()) {
-            List<DateMatcher<EmployeeAvailabilityState>> exceptions = (null != employeeInfo.getAvailabilityConditionList())
-                    ? employeeInfo.getAvailabilityConditionList().stream()
-                    .map((e) -> {
-                        try {
-                            return DateMatcher.getDateMatcher(e);
-                        } catch (Exception bad) {
-                            return null;
-                        }
-                            }).collect(Collectors.toList()) : Collections.emptyList();
+            List<DateMatcher<EmployeeAvailabilityState>> exceptions = (null != employeeInfo
+                    .getAvailabilityConditionList())
+                            ? employeeInfo.getAvailabilityConditionList().stream()
+                                  .map((e) -> {
+                                      try {
+                                          return DateMatcher.getDateMatcher(e);
+                                      } catch (Exception bad) {
+                                          return null;
+                                      }
+                                  }).collect(Collectors.toList()) : Collections.emptyList();
             if (exceptions.contains(null)) {
                 throw new ParserException("Badly formatted date exception string");
             }
             Optional<DateMatcher<EmployeeAvailabilityState>> employeeStateCond = exceptions.stream()
-                    .filter((cond) -> cond.test(state.startDate)).findFirst();
+                                                                                           .filter((cond) -> cond.test(state.startDate)).findFirst();
             EmployeeAvailabilityState employeeState = employeeInfo.getDefaultAvailability();
 
             if (employeeStateCond.isPresent()) {
@@ -236,15 +242,15 @@ public class ShiftFileParser {
             if (employeeInfo.getEmployeeId().getIsGroup()) {
                 for (Employee employee : state.employeeGroupMap.get(employeeInfo.getEmployeeId().getItemId())) {
                     EmployeeAvailability employeeAvailability = new EmployeeAvailability(state.tenantId,
-                            employee, timeslot);
+                                                                                         employee, timeslot);
                     employeeAvailability.setState(employeeState);
-                    state.employeeAvailabilityOutputList.add(employeeAvailability);
+                    state.employeeAvailabityOutputList.add(employeeAvailability);
                 }
             } else {
                 EmployeeAvailability employeeAvailability = new EmployeeAvailability(state.tenantId,
-                        state.employeeMap.get(employeeInfo.getEmployeeId().getItemId()), timeslot);
+                                                                                     state.employeeMap.get(employeeInfo.getEmployeeId().getItemId()), timeslot);
                 employeeAvailability.setState(employeeState);
-                state.employeeAvailabilityOutputList.add(employeeAvailability);
+                state.employeeAvailabityOutputList.add(employeeAvailability);
             }
 
         }
@@ -254,7 +260,7 @@ public class ShiftFileParser {
 
         Integer tenantId;
         List<Shift> shiftOutputList;
-        List<EmployeeAvailability> employeeAvailabilityOutputList;
+        List<EmployeeAvailability> employeeAvailabityOutputList;
         List<DateMatcher<ShiftInfo>> universalExceptionList;
         Map<Long, Spot> spotMap;
         Map<Long, Employee> employeeMap;

--- a/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/roster/RosterGenerator.java
+++ b/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/roster/RosterGenerator.java
@@ -39,6 +39,7 @@ import org.optaplanner.openshift.employeerostering.shared.employee.EmployeeAvail
 import org.optaplanner.openshift.employeerostering.shared.employee.EmployeeAvailabilityState;
 import org.optaplanner.openshift.employeerostering.shared.lang.tokens.EmployeeTimeSlotInfo;
 import org.optaplanner.openshift.employeerostering.shared.lang.tokens.IdOrGroup;
+import org.optaplanner.openshift.employeerostering.shared.lang.tokens.OptionalEmployee;
 import org.optaplanner.openshift.employeerostering.shared.lang.tokens.ShiftInfo;
 import org.optaplanner.openshift.employeerostering.shared.roster.Roster;
 import org.optaplanner.openshift.employeerostering.shared.shift.Shift;
@@ -98,19 +99,20 @@ public class RosterGenerator {
     @PostConstruct
     public void setUpGeneratedData() {
         tenantNameGenerator.predictMaximumSizeAndReset(10);
-        generateRoster(10, 7, false);
-        generateRoster(10, 7 * 4, false);
-        generateRoster(20, 7 * 4, false);
-        generateRoster(40, 7 * 2, false);
-        generateRoster(80, 7 * 4, false);
-        generateRoster(10, 7 * 4, true);
-        generateRoster(20, 7 * 4, true);
-        generateRoster(40, 7 * 2, true);
-        generateRoster(80, 7 * 4, true);
+        generateRoster(10, 7, false, false);
+        generateRoster(10, 7 * 4, false, false);
+        generateRoster(20, 7 * 4, false, true);
+        generateRoster(40, 7 * 2, false, false);
+        generateRoster(80, 7 * 4, false, true);
+        generateRoster(10, 7 * 4, true, false);
+        generateRoster(20, 7 * 4, true, true);
+        generateRoster(40, 7 * 2, true, false);
+        generateRoster(80, 7 * 4, true, true);
     }
 
     @Transactional
-    public Roster generateRoster(int spotListSize, int timeSlotListSize, boolean continuousPlanning) {
+    public Roster generateRoster(int spotListSize, int timeSlotListSize, boolean continuousPlanning,
+            boolean assignDefaultEmployee) {
         int employeeListSize = spotListSize * 7 / 2;
         int skillListSize = (spotListSize + 4) / 5;
         Integer tenantId = createTenant(spotListSize, employeeListSize);
@@ -119,7 +121,8 @@ public class RosterGenerator {
 
         List<Employee> employeeList = createEmployeeList(tenantId, employeeListSize, skillList);
 
-        shiftRestService.createTemplate(tenantId, generateShiftTemplate(tenantId, spotList, employeeList));
+        shiftRestService.createTemplate(tenantId, generateShiftTemplate(tenantId, spotList, employeeList,
+                assignDefaultEmployee));
         LocalDateTime previousEndDateTime = LocalDateTime.of(2017, 2, 1, 6, 0);
         for (int i = 0; i < timeSlotListSize; i += 7) {
             try {
@@ -152,7 +155,8 @@ public class RosterGenerator {
                           tenant.getConfiguration(), shiftList);
     }
 
-    private List<ShiftInfo> generateShiftTemplate(Integer tenantId, List<Spot> spots, List<Employee> employees) {
+    private List<ShiftInfo> generateShiftTemplate(Integer tenantId, List<Spot> spots, List<Employee> employees,
+            boolean assignDefaultEmployee) {
         LocalDateTime startTime = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC).plusHours(6);
         List<ShiftInfo> out = new ArrayList<ShiftInfo>(7);
         for (int i = 0; i < 7 * 3; i++) {
@@ -193,6 +197,7 @@ public class RosterGenerator {
 
             //Generate spots using the timeslot
             List<IdOrGroup> shiftSpots = new ArrayList<>();
+            List<OptionalEmployee> rotationEmployeeList = new ArrayList<>();
             for (Spot spot : spots) {
                 boolean weekendEnabled = random.nextInt(10) < 8;
                 boolean nightEnabled = weekendEnabled && random.nextInt(10) < 8;
@@ -201,7 +206,14 @@ public class RosterGenerator {
                     continue;
                 }
                 shiftSpots.add(new IdOrGroup(tenantId, false, spot.getId()));
+                if (assignDefaultEmployee) {
+                    rotationEmployeeList.add(new OptionalEmployee(tenantId, employees.get(random.nextInt(employees
+                            .size()))));
+                } else {
+                    rotationEmployeeList.add(new OptionalEmployee(tenantId, null));
+                }
             }
+            shift.setRotationEmployeeList(rotationEmployeeList);
             shift.setSpotList(shiftSpots);
             out.add(shift);
 
@@ -233,7 +245,8 @@ public class RosterGenerator {
         spotNameGenerator.predictMaximumSizeAndReset(size);
         for (int i = 0; i < size; i++) {
             String name = spotNameGenerator.generateNextValue();
-            Spot spot = new Spot(tenantId, name, new HashSet<>(extractRandomSubList(skillList, 1.0)));
+            Spot spot = new Spot(tenantId, name, extractRandomSubListOfLength(skillList, random.nextInt(skillList
+                    .size())).stream().collect(Collectors.toSet()));
             entityManager.persist(spot);
             spotList.add(spot);
         }
@@ -258,8 +271,18 @@ public class RosterGenerator {
     private <E> List<E> extractRandomSubList(List<E> list, double maxRelativeSize) {
         List<E> subList = new ArrayList<>(list);
         Collections.shuffle(subList, random);
-        // TODO List.subList() doesn't allow outer list to be garbage collected
-        return subList.subList(0, random.nextInt((int) (list.size() * maxRelativeSize)) + 1);
+        int size = random.nextInt((int) (list.size() * maxRelativeSize)) + 1;
+        // Remove elements not in the sublist (so it can be garbage collected)
+        subList.subList(size, subList.size()).clear();
+        return subList;
+    }
+
+    private <E> List<E> extractRandomSubListOfLength(List<E> list, int length) {
+        List<E> subList = new ArrayList<>(list);
+        Collections.shuffle(subList, random);
+        // Remove elements not in the sublist (so it can be garbage collected)
+        subList.subList(length, subList.size()).clear();
+        return subList;
     }
 
     // TODO: Implement some of the logic from these methods into generateShiftTemplate

--- a/optashift-employee-rostering-server/src/main/resources/org/optaplanner/openshift/employeerostering/server/solver/employeeRosteringScoreRules.drl
+++ b/optashift-employee-rostering-server/src/main/resources/org/optaplanner/openshift/employeerostering/server/solver/employeeRosteringScoreRules.drl
@@ -118,3 +118,12 @@ rule "Desired time slot for an employee"
     then
         scoreHolder.addSoftConstraintMatch(kcontext, +$tenantConfiguration.getDesiredTimeSlotWeight());
 end
+
+rule "Employee is not rotation employee"
+    when
+    	$tenantConfiguration : TenantConfiguration(rotationEmployeeMatchWeight != 0)
+        Shift(  
+                rotationEmployee != null && employee != rotationEmployee)
+    then
+        scoreHolder.addSoftConstraintMatch(kcontext, -$tenantConfiguration.getRotationEmployeeMatchWeight());
+end

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/lang/tokens/OptionalEmployee.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/lang/tokens/OptionalEmployee.java
@@ -1,0 +1,30 @@
+package org.optaplanner.openshift.employeerostering.shared.lang.tokens;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+import org.optaplanner.openshift.employeerostering.shared.common.AbstractPersistable;
+import org.optaplanner.openshift.employeerostering.shared.employee.Employee;
+
+@Entity
+public class OptionalEmployee extends AbstractPersistable {
+
+    @ManyToOne
+    private Employee employee;
+
+    @SuppressWarnings("unused")
+    public OptionalEmployee() {}
+
+    public OptionalEmployee(Integer tenantId, Employee employee) {
+        super(tenantId);
+        this.employee = employee;
+    }
+
+    public Employee getEmployee() {
+        return employee;
+    }
+
+    public void setEmployee(Employee employee) {
+        this.employee = employee;
+    }
+}

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/lang/tokens/ShiftInfo.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/lang/tokens/ShiftInfo.java
@@ -1,6 +1,7 @@
 package org.optaplanner.openshift.employeerostering.shared.lang.tokens;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.CascadeType;
@@ -81,11 +82,21 @@ public class ShiftInfo extends AbstractPersistable {
     @OrderColumn(name = "orderIndex")
     List<ShiftConditional> exceptionList;
 
+    /**
+     * List of preferred employee for a spot. Must have same length as the number
+     * of non-group entries in {@link ShiftInfo#spots}.
+     * Entries can be null.
+     */
+    @ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OrderColumn(name = "orderIndex")
+    List<OptionalEmployee> rotationEmployeeList;
+
     public ShiftInfo() {
     }
 
     public ShiftInfo(Integer tenantId, ShiftInfo src) {
-        this(tenantId, src.startTime, src.endTime, src.spotList, src.employeeList, src.exceptionList);
+        this(tenantId, src.startTime, src.endTime, src.spotList, src.employeeList, src.exceptionList,
+                src.rotationEmployeeList);
     }
 
     public ShiftInfo(Integer tenantId, LocalDateTime startTime, LocalDateTime endTime, List<IdOrGroup> spots, List<
@@ -95,16 +106,34 @@ public class ShiftInfo extends AbstractPersistable {
         this.endTime = endTime;
         this.spotList = spots;
         this.employeeList = employees;
+        this.rotationEmployeeList = new ArrayList<>(spots.size());
+        for (int i = 0; i < this.rotationEmployeeList.size(); i++) {
+            this.rotationEmployeeList.set(i, new OptionalEmployee(tenantId, null));
+        }
     }
 
     public ShiftInfo(Integer tenantId, LocalDateTime startTime, LocalDateTime endTime, List<IdOrGroup> spots, List<
             EmployeeTimeSlotInfo> employees, List<ShiftConditional> exceptions) {
+        this(tenantId, startTime, endTime, spots, employees, exceptions, null);
+    }
+
+    public ShiftInfo(Integer tenantId, LocalDateTime startTime, LocalDateTime endTime, List<IdOrGroup> spots, List<
+            EmployeeTimeSlotInfo> employees, List<ShiftConditional> exceptions,
+            List<OptionalEmployee> rotationEmployees) {
         super(tenantId);
         this.startTime = startTime;
         this.endTime = endTime;
         this.spotList = spots;
         this.employeeList = employees;
         this.exceptionList = exceptions;
+        if (rotationEmployees != null) {
+            this.rotationEmployeeList = rotationEmployees;
+        } else {
+            this.rotationEmployeeList = new ArrayList<>(spots.size());
+            for (int i = 0; i < this.rotationEmployeeList.size(); i++) {
+                this.rotationEmployeeList.set(i, new OptionalEmployee(tenantId, null));
+            }
+        }
     }
 
     /**
@@ -190,6 +219,14 @@ public class ShiftInfo extends AbstractPersistable {
      */
     public void setEndTime(LocalDateTime endTime) {
         this.endTime = endTime;
+    }
+
+    public List<OptionalEmployee> getRotationEmployeeList() {
+        return rotationEmployeeList;
+    }
+
+    public void setRotationEmployeeList(List<OptionalEmployee> rotationEmployeeList) {
+        this.rotationEmployeeList = rotationEmployeeList;
     }
 
 }

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/Shift.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/Shift.java
@@ -32,17 +32,20 @@ import org.optaplanner.openshift.employeerostering.shared.timeslot.TimeSlot;
 
 @Entity
 @NamedQueries({
-        @NamedQuery(name = "Shift.findAll",
-                query = "select distinct sa from Shift sa" +
-                        " left join fetch sa.spot s" +
-                        " left join fetch sa.timeSlot t" +
-                        " left join fetch sa.employee e" +
-                        " where sa.tenantId = :tenantId" +
-                        " order by t.startDateTime, s.name, e.name"),
+               @NamedQuery(name = "Shift.findAll",
+                           query = "select distinct sa from Shift sa" +
+                                   " left join fetch sa.spot s" +
+                                   " left join fetch sa.timeSlot t" +
+                                   " left join fetch sa.rotationEmployee re" +
+                                   " left join fetch sa.employee e" +
+                                   " where sa.tenantId = :tenantId" +
+                                   " order by t.startDateTime, s.name, e.name"),
 })
 @PlanningEntity(movableEntitySelectionFilter = MovableShiftFilter.class)
 public class Shift extends AbstractPersistable {
 
+    @ManyToOne
+    private Employee rotationEmployee;
     @NotNull
     @ManyToOne
     private Spot spot;
@@ -57,20 +60,29 @@ public class Shift extends AbstractPersistable {
     private Employee employee = null;
 
     @SuppressWarnings("unused")
-    public Shift() {
-    }
+    public Shift() {}
 
     public Shift(Integer tenantId, Spot spot, TimeSlot timeSlot) {
+        this(tenantId, spot, timeSlot, null);
+    }
+
+    public Shift(Integer tenantId, Spot spot, TimeSlot timeSlot, Employee rotationEmployee) {
         super(tenantId);
         this.timeSlot = timeSlot;
         this.spot = spot;
+        this.rotationEmployee = rotationEmployee;
     }
 
     public Shift(ShiftView shiftView, Spot spot, TimeSlot timeSlot) {
+        this(shiftView, spot, timeSlot, null);
+    }
+
+    public Shift(ShiftView shiftView, Spot spot, TimeSlot timeSlot, Employee rotationEmployee) {
         super(shiftView);
         this.timeSlot = timeSlot;
         this.spot = spot;
         this.lockedByUser = shiftView.isLockedByUser();
+        this.rotationEmployee = rotationEmployee;
     }
 
     @Override
@@ -112,6 +124,14 @@ public class Shift extends AbstractPersistable {
 
     public void setEmployee(Employee employee) {
         this.employee = employee;
+    }
+
+    public Employee getRotationEmployee() {
+        return rotationEmployee;
+    }
+
+    public void setRotationEmployee(Employee rotationEmployee) {
+        this.rotationEmployee = rotationEmployee;
     }
 
 }

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/view/ShiftView.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/view/ShiftView.java
@@ -19,12 +19,14 @@ package org.optaplanner.openshift.employeerostering.shared.shift.view;
 import javax.validation.constraints.NotNull;
 
 import org.optaplanner.openshift.employeerostering.shared.common.AbstractPersistable;
+import org.optaplanner.openshift.employeerostering.shared.employee.Employee;
 import org.optaplanner.openshift.employeerostering.shared.shift.Shift;
 import org.optaplanner.openshift.employeerostering.shared.spot.Spot;
 import org.optaplanner.openshift.employeerostering.shared.timeslot.TimeSlot;
 
 public class ShiftView extends AbstractPersistable {
 
+    private Long rotationEmployeeId;
     @NotNull
     private Long spotId;
     @NotNull
@@ -35,13 +37,17 @@ public class ShiftView extends AbstractPersistable {
     private Long employeeId = null;
 
     @SuppressWarnings("unused")
-    public ShiftView() {
-    }
+    public ShiftView() {}
 
     public ShiftView(Integer tenantId, Spot spot, TimeSlot timeSlot) {
+        this(tenantId, spot, timeSlot, null);
+    }
+
+    public ShiftView(Integer tenantId, Spot spot, TimeSlot timeSlot, Employee rotationEmployee) {
         super(tenantId);
         this.spotId = spot.getId();
         this.timeSlotId = timeSlot.getId();
+        this.rotationEmployeeId = (rotationEmployee == null) ? null : rotationEmployee.getId();
     }
 
     public ShiftView(Shift shift) {
@@ -49,6 +55,7 @@ public class ShiftView extends AbstractPersistable {
         this.spotId = shift.getSpot().getId();
         this.timeSlotId = shift.getTimeSlot().getId();
         this.lockedByUser = shift.isLockedByUser();
+        this.rotationEmployeeId = (shift.getRotationEmployee() == null) ? null : shift.getRotationEmployee().getId();
         this.employeeId = (shift.getEmployee() == null) ? null : shift.getEmployee().getId();
     }
 
@@ -91,6 +98,14 @@ public class ShiftView extends AbstractPersistable {
 
     public void setEmployeeId(Long employeeId) {
         this.employeeId = employeeId;
+    }
+
+    public Long getRotationEmployeeId() {
+        return rotationEmployeeId;
+    }
+
+    public void setRotationEmployeeId(Long rotationEmployeeId) {
+        this.rotationEmployeeId = rotationEmployeeId;
     }
 
 }

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/tenant/TenantConfiguration.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/tenant/TenantConfiguration.java
@@ -10,10 +10,13 @@ import org.optaplanner.openshift.employeerostering.shared.common.AbstractPersist
 @Entity
 public class TenantConfiguration extends AbstractPersistable {
 
+    // TODO: Is 999 a reasonable max for the weights?
     @NotNull
     private Integer undesiredTimeSlotWeight = 100;
     @NotNull
     private Integer desiredTimeSlotWeight = 10;
+    @NotNull
+    private Integer rotationEmployeeMatchWeight = 500;
     @NotNull
     private Integer templateDuration = 1;
     @NotNull
@@ -25,12 +28,14 @@ public class TenantConfiguration extends AbstractPersistable {
     }
 
     public TenantConfiguration(Integer tenantId, Integer templateDuration, DayOfWeek weekStart,
-                               Integer undesiredTimeSlotWeight, Integer desiredTimeSlotWeight) {
+                               Integer undesiredTimeSlotWeight, Integer desiredTimeSlotWeight,
+                               Integer rotationEmployeeMatchWeight) {
         super(tenantId);
         this.templateDuration = templateDuration;
         this.weekStart = weekStart;
         this.undesiredTimeSlotWeight = undesiredTimeSlotWeight;
         this.desiredTimeSlotWeight = desiredTimeSlotWeight;
+        this.rotationEmployeeMatchWeight = rotationEmployeeMatchWeight;
     }
 
     public Integer getUndesiredTimeSlotWeight() {
@@ -47,6 +52,14 @@ public class TenantConfiguration extends AbstractPersistable {
 
     public void setDesiredTimeSlotWeight(Integer desiredTimeSlotWeight) {
         this.desiredTimeSlotWeight = desiredTimeSlotWeight;
+    }
+
+    public Integer getRotationEmployeeMatchWeight() {
+        return rotationEmployeeMatchWeight;
+    }
+
+    public void setRotationEmployeeMatchWeight(Integer rotationEmployeeMatchWeight) {
+        this.rotationEmployeeMatchWeight = rotationEmployeeMatchWeight;
     }
 
     public Integer getTemplateDuration() {


### PR DESCRIPTION
The main functionality is implemented; But I still need to add more visual indicators to indicate when the employee is not the rotation employee in the spot and employee roster. @ge0ffrey can you verify I did the drools rule correctly?