### PR TITLE
PLANNER-1055: Added visual indication of Historic, Published and Draft shifts

### DIFF
--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/ShiftBlob.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/ShiftBlob.java
@@ -86,8 +86,8 @@ public class ShiftBlob implements Blob<OffsetDateTime> {
 
     public String getLabel() {
         return Optional.ofNullable(shift.getEmployee())
-                       .map(Employee::getName)
-                       .orElse("U" + " [" + getPositionInScaleUnits() + " ~ " + getEndPositionInScaleUnits() + ", " + getSizeInGridPixels() + "]");
+                .map(Employee::getName)
+                .orElse("Unassigned");
     }
 
     public Shift getShift() {

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/ShiftBlobView.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/ShiftBlobView.java
@@ -35,6 +35,7 @@ import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.model
 import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.model.Viewport;
 import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.powers.BlobPopover;
 import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.view.BlobView;
+import org.optaplanner.openshift.employeerostering.shared.roster.RosterState;
 
 @Templated
 public class ShiftBlobView implements BlobView<OffsetDateTime, ShiftBlob> {
@@ -53,6 +54,9 @@ public class ShiftBlobView implements BlobView<OffsetDateTime, ShiftBlob> {
 
     @Inject
     private BlobPopover popover;
+
+    @Inject
+    private SpotRosterPage page;
 
     private Viewport<OffsetDateTime> viewport;
     private ListView<ShiftBlob> blobViews;
@@ -76,22 +80,25 @@ public class ShiftBlobView implements BlobView<OffsetDateTime, ShiftBlob> {
 
     public void refresh() {
 
-        if (blob.getShift().isPinnedByUser()) {
-            getElement().classList.add("pinned");
-        } else {
-            getElement().classList.remove("pinned");
-        }
-
-        if (blob.getShift().getEmployee() == null) {
-            getElement().classList.add("unassigned");
-        } else {
-            getElement().classList.remove("unassigned");
-        }
+        setClassProperty("pinned", blob.getShift().isPinnedByUser());
+        setClassProperty("unassigned", blob.getShift().getEmployee() == null);
+        RosterState rosterState = page.getCurrentSpotRosterView().getRosterState();
+        setClassProperty("historic", rosterState.isHistoric(blob.getShift()));
+        setClassProperty("published", rosterState.isPublished(blob.getShift()));
+        setClassProperty("draft", rosterState.isDraft(blob.getShift()));
 
         viewport.setPositionInScreenPixels(this, blob.getPositionInGridPixels(), BLOB_POSITION_DISPLACEMENT_IN_SCREEN_PIXELS);
         viewport.setSizeInScreenPixels(this, blob.getSizeInGridPixels(), BLOB_SIZE_DISPLACEMENT_IN_SCREEN_PIXELS);
 
         updateLabel();
+    }
+
+    private void setClassProperty(String clazz, boolean isSet) {
+        if (isSet) {
+            getElement().classList.add(clazz);
+        } else {
+            getElement().classList.remove(clazz);
+        }
     }
 
     private boolean onResize(final Long newSizeInGridPixels) {

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/SpotRosterPage.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/SpotRosterPage.java
@@ -20,6 +20,7 @@ import java.time.OffsetDateTime;
 import java.util.Optional;
 
 import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -50,9 +51,9 @@ import static elemental2.dom.DomGlobal.setTimeout;
 import static java.lang.Math.max;
 import static org.optaplanner.openshift.employeerostering.gwtui.client.common.FailureShownRestCallback.onSuccess;
 import static org.optaplanner.openshift.employeerostering.gwtui.client.util.PromiseUtils.resolve;
-import static org.optaplanner.openshift.employeerostering.shared.roster.RosterRestServiceBuilder.getCurrentSpotRosterView;
 
 @Templated
+@ApplicationScoped
 public class SpotRosterPage implements Page {
 
     private static final Integer SOLVE_TIME_IN_SECONDS = 30;
@@ -134,6 +135,7 @@ public class SpotRosterPage implements Page {
 
     private SpotRosterViewport viewport;
     private Pagination spotsPagination = Pagination.of(0, 10);
+    private SpotRosterView currentSpotRosterView;
 
     @PostConstruct
     public void init() {
@@ -151,7 +153,7 @@ public class SpotRosterPage implements Page {
 
     private Promise<Void> refreshWithoutLoadingSpinner() {
         return fetchSpotRosterView().then(spotRosterView -> {
-
+            currentSpotRosterView = spotRosterView;
             final Optional<HardSoftScore> score = Optional.ofNullable(spotRosterView.getScore());
 
             if (score.isPresent()) {
@@ -280,6 +282,10 @@ public class SpotRosterPage implements Page {
         viewportFrame.scrollLeft -= TIME_SCROLL_SIZE;
     }
 
+    public SpotRosterView getCurrentSpotRosterView() {
+        return currentSpotRosterView;
+    }
+
     //API calls
 
     private Promise<Void> triggerRosterSolve() {
@@ -296,9 +302,9 @@ public class SpotRosterPage implements Page {
 
     private Promise<SpotRosterView> fetchSpotRosterView() {
         return new Promise<>((resolve, reject) -> {
-            getCurrentSpotRosterView(tenantStore.getCurrentTenantId(),
-                                     spotsPagination.getPageNumber(),
-                                     spotsPagination.getNumberOfItemsPerPage(), onSuccess(resolve::onInvoke));
+            RosterRestServiceBuilder.getCurrentSpotRosterView(tenantStore.getCurrentTenantId(),
+                    spotsPagination.getPageNumber(),
+                    spotsPagination.getNumberOfItemsPerPage(), onSuccess(resolve::onInvoke));
         });
     }
 }

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/SpotRosterPage.css
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/SpotRosterPage.css
@@ -1,3 +1,8 @@
+@font-face {
+    font-family: PatternFlyIcons;
+    src: url(fonts/PatternFlyIcons-webfont.ttf);
+}
+
 .viewport-frame div {
     box-sizing: border-box;
 }
@@ -219,15 +224,29 @@
     margin-bottom: 0;
 }
 
-.pinned {
-    border: 2px dashed black !important;
-}
-
 .locked-for-interaction {
     opacity: 0.7;
     pointer-events: none;
 }
 
+/* Blobs */
+
 .unassigned {
     background-color: rgba(0, 0, 0, 0.1) !important;
+}
+
+.historic {
+}
+
+.published {
+    border: 2px solid black !important;
+}
+
+.draft {
+    border: 2px dashed black !important;
+}
+
+.pinned:before {
+	font-family: FontAwesome;
+    content: "\f08d"; /*Pin*/
 }

--- a/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/roster/RosterRestServiceImpl.java
+++ b/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/roster/RosterRestServiceImpl.java
@@ -133,6 +133,7 @@ public class RosterRestServiceImpl extends AbstractRestServiceImpl implements Ro
 
         //Score
         spotRosterView.setScore(solverManager.getRoster(tenantId).map(Roster::getScore).orElse(null));
+        spotRosterView.setRosterState(getRosterState(tenantId));
 
         return spotRosterView;
     }
@@ -213,6 +214,7 @@ public class RosterRestServiceImpl extends AbstractRestServiceImpl implements Ro
         if (null != roster) {
             employeeRosterView.setScore(roster.getScore());
         }
+        employeeRosterView.setRosterState(getRosterState(tenantId));
         return employeeRosterView;
     }
 
@@ -273,5 +275,10 @@ public class RosterRestServiceImpl extends AbstractRestServiceImpl implements Ro
             attachedShift.setEmployee((shift.getEmployee() == null)
                     ? null : employeeIdMap.get(shift.getEmployee().getId()));
         }
+    }
+
+    // TODO: Make this a REST method?
+    private RosterState getRosterState(Integer tenantId) {
+        return entityManager.find(Tenant.class, tenantId).getRosterState();
     }
 }

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/roster/RosterState.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/roster/RosterState.java
@@ -103,21 +103,20 @@ public class RosterState extends AbstractPersistable {
         return shift.getEndDateTime().isBefore(OffsetDateTime.of(getFirstPublishedDate().atTime(LocalTime.MIDNIGHT), shift.getEndDateTime().getOffset()));
     }
 
-    @JsonIgnore
+    // Do we need this, since if a shift exists, it would be draft...
+    /*@JsonIgnore
     public boolean isUnplanned(Shift shift) {
         return shift.getStartDateTime().isAfter(OffsetDateTime.of(getLastDraftDate().atTime(LocalTime.MIDNIGHT), shift.getStartDateTime().getOffset()));
-    }
+    }*/
 
     @JsonIgnore
     public boolean isDraft(Shift shift) {
-        return shift.getStartDateTime().isBefore(OffsetDateTime.of(getLastDraftDate().atTime(LocalTime.MIDNIGHT), shift.getStartDateTime().getOffset())) &&
-               shift.getEndDateTime().isAfter(OffsetDateTime.of(getFirstDraftDate().atTime(LocalTime.MIDNIGHT), shift.getEndDateTime().getOffset()));
+        return shift.getStartDateTime().isAfter(OffsetDateTime.of(getFirstDraftDate().atTime(LocalTime.MIDNIGHT), shift.getStartDateTime().getOffset()));
     }
 
     @JsonIgnore
     public boolean isPublished(Shift shift) {
-        return shift.getStartDateTime().isBefore(OffsetDateTime.of(getFirstDraftDate().atTime(LocalTime.MIDNIGHT), shift.getStartDateTime().getOffset())) &&
-               shift.getEndDateTime().isAfter(OffsetDateTime.of(getFirstPublishedDate().atTime(LocalTime.MIDNIGHT), shift.getEndDateTime().getOffset()));
+        return !isHistoric(shift) && !isDraft(shift);
     }
 
     @JsonIgnore


### PR DESCRIPTION
 Historic shifts are not visible in the current implementation (as there are none currently), but would look have no outline
Pinning a shift cause a pin to appear next to the shift text
Published shifts have a solid line, draft shifts have a dotted line