### PR TITLE
PLANNER-1047: Auto-focus on first input element when editing/creating a Skill/Employee/Spot

### DIFF
--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/common/TableRow.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/common/TableRow.java
@@ -109,6 +109,10 @@ public abstract class TableRow<T> extends Composite implements TakesValue<T> {
         }
         presenter.hidden = isEditing;
         editor.hidden = !isEditing;
+
+        if (isEditing) {
+            focusOnFirstInput();
+        }
     }
 
     public void markAsCreator(ListComponent<T, ?> table, KiePager<T> pager) {
@@ -166,6 +170,8 @@ public abstract class TableRow<T> extends Composite implements TakesValue<T> {
     protected boolean isCreatingRow() {
         return null != table;
     }
+
+    protected abstract void focusOnFirstInput();
 
     protected abstract void deleteRow(T value);
 

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/employee/EmployeeSubform.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/employee/EmployeeSubform.java
@@ -133,4 +133,9 @@ public class EmployeeSubform extends TableRow<Employee> implements TakesValue<Em
     public void onUnload() {
         subscription.remove();
     }
+
+    @Override
+    protected void focusOnFirstInput() {
+        employeeName.setFocus(true);
+    }
 }

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/skill/SkillSubform.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/skill/SkillSubform.java
@@ -44,7 +44,7 @@ public class SkillSubform extends TableRow<Skill> implements TakesValue<Skill> {
     @PostConstruct
     protected void initWidget() {
         skillName.getElement().setAttribute("placeholder", translationService.format(
-                                                                                     OptaShiftUIConstants.SkillListPanel_skillName));
+                OptaShiftUIConstants.SkillListPanel_skillName));
         dataBinder.getModel().setTenantId(tenantStore.getCurrentTenantId());
         dataBinder.bind(skillName, "name");
 
@@ -60,24 +60,29 @@ public class SkillSubform extends TableRow<Skill> implements TakesValue<Skill> {
     @Override
     protected void deleteRow(Skill skill) {
         SkillRestServiceBuilder.removeSkill(tenantStore.getCurrentTenantId(), skill.getId(),
-                                            FailureShownRestCallback.onSuccess(success -> {
-                                                dataInvalidationEvent.fire(new DataInvalidation<>());
-                                            }));
+                FailureShownRestCallback.onSuccess(success -> {
+                    dataInvalidationEvent.fire(new DataInvalidation<>());
+                }));
     }
 
     @Override
     protected void updateRow(Skill oldValue, Skill newValue) {
         SkillRestServiceBuilder.updateSkill(tenantStore.getCurrentTenantId(), newValue,
-                                            FailureShownRestCallback.onSuccess(v -> {
-                                                dataInvalidationEvent.fire(new DataInvalidation<>());
-                                            }));
+                FailureShownRestCallback.onSuccess(v -> {
+                    dataInvalidationEvent.fire(new DataInvalidation<>());
+                }));
     }
 
     @Override
     protected void createRow(Skill skill) {
         SkillRestServiceBuilder.addSkill(tenantStore.getCurrentTenantId(), skill,
-                                         FailureShownRestCallback.onSuccess(v -> {
-                                             dataInvalidationEvent.fire(new DataInvalidation<>());
-                                         }));
+                FailureShownRestCallback.onSuccess(v -> {
+                    dataInvalidationEvent.fire(new DataInvalidation<>());
+                }));
+    }
+
+    @Override
+    protected void focusOnFirstInput() {
+        skillName.setFocus(true);
     }
 }

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/spot/SpotSubform.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/spot/SpotSubform.java
@@ -133,4 +133,9 @@ public class SpotSubform extends TableRow<Spot> implements TakesValue<Spot> {
     public void onUnload() {
         subscription.remove();
     }
+
+    @Override
+    protected void focusOnFirstInput() {
+        spotName.setFocus(true);
+    }
 }


### PR DESCRIPTION
You can switch between input elements using tab, type into the select box to find and select skills, and click on save/cancel/whatever using enter