### PR TITLE
DO NOT MERGE - OffsetDateTimeHibernateType to fix the ZoneOffset time lost problem

### DIFF
--- a/optashift-employee-rostering-server/pom.xml
+++ b/optashift-employee-rostering-server/pom.xml
@@ -24,6 +24,13 @@
       <artifactId>javaee-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- Hibernate -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <!-- Used at compile time by OffsetDateTimeHibernateType -->
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>

--- a/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/common/jpa/OffsetDateTimeHibernateType.java
+++ b/optashift-employee-rostering-server/src/main/java/org/optaplanner/openshift/employeerostering/server/common/jpa/OffsetDateTimeHibernateType.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.openshift.employeerostering.server.common.jpa;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.Type;
+import org.hibernate.usertype.CompositeUserType;
+
+/**
+ * This class is Hibernate specific, because JPA 2.1's @Converter currently
+ * cannot handle 1 class mapping to 2 SQL columns.
+ */
+public class OffsetDateTimeHibernateType implements CompositeUserType {
+
+    @Override
+    public Class returnedClass() {
+        return OffsetDateTime.class;
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+        return new String[] {"dateTime", "zoneOffset"};
+    }
+
+    @Override
+    public Type[] getPropertyTypes() {
+        // Not sure if we should use LocalDateTimeType.INSTANCE instead of TIMESTAMP
+        return new Type[]{StandardBasicTypes.TIMESTAMP, StandardBasicTypes.INTEGER};
+    }
+
+    @Override
+    public Object getPropertyValue(Object o, int propertyIndex) {
+        if (o == null) {
+            return null;
+        }
+        OffsetDateTime offsetDateTime = (OffsetDateTime) o;
+        switch (propertyIndex) {
+            case 0:
+                return Timestamp.valueOf(offsetDateTime.toLocalDateTime());
+            case 1:
+                return offsetDateTime.getOffset().getTotalSeconds();
+            default:
+                throw new IllegalArgumentException("The propertyIndex (" + propertyIndex
+                        + ") must be 0 or 1.");
+        }
+    }
+
+    @Override
+    public OffsetDateTime nullSafeGet(ResultSet resultSet, String[] names, SessionImplementor session, Object owner)
+            throws SQLException {
+        if (resultSet == null) {
+            return null;
+        }
+        Timestamp timestamp = (Timestamp) StandardBasicTypes.TIMESTAMP.nullSafeGet(resultSet, names[0], session, owner);
+        if (timestamp == null) {
+            throw new IllegalStateException("The timestamp (" + timestamp + ") for an "
+                    + OffsetDateTime.class.getSimpleName() + "cannot be null.");
+        }
+        LocalDateTime localDateTime = timestamp.toLocalDateTime();
+        Integer zoneOffsetSeconds = (Integer) StandardBasicTypes.INTEGER.nullSafeGet(resultSet, names[1], session, owner);
+        if (zoneOffsetSeconds == null) {
+            throw new IllegalStateException("The zoneOffsetSeconds (" + zoneOffsetSeconds + ") for an "
+                    + OffsetDateTime.class.getSimpleName() + "cannot be null.");
+        }
+        return OffsetDateTime.of(localDateTime, ZoneOffset.ofTotalSeconds(zoneOffsetSeconds));
+    }
+
+    @Override
+    public void nullSafeSet(PreparedStatement statement, Object value, int parameterIndex, SessionImplementor session)
+            throws SQLException {
+        if (value == null) {
+            statement.setNull(parameterIndex, StandardBasicTypes.TIMESTAMP.sqlType());
+            statement.setNull(parameterIndex, StandardBasicTypes.INTEGER.sqlType());
+            return;
+        }
+        OffsetDateTime offsetDateTime = (OffsetDateTime) value;
+        statement.setTimestamp(parameterIndex, Timestamp.valueOf(offsetDateTime.toLocalDateTime()));
+        statement.setInt(parameterIndex, offsetDateTime.getOffset().getTotalSeconds());
+    }
+
+    // ************************************************************************
+    // Mutable related methods
+    // ************************************************************************
+
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    @Override
+    public Object deepCopy(Object value) {
+        return value; // OffsetDateTime is immutable
+    }
+
+    @Override
+    public Object replace(Object original, Object target, SessionImplementor session, Object owner) {
+        return original; // OffsetDateTime is immutable
+    }
+
+    @Override
+    public void setPropertyValue(Object component, int property, Object value) {
+        throw new UnsupportedOperationException("A OffsetDateTime is immutable.");
+    }
+
+    // ************************************************************************
+    // Other methods
+    // ************************************************************************
+
+    @Override
+    public boolean equals(Object a, Object b) {
+        if (a == b) {
+            return true;
+        } else if (a == null || b == null) {
+            return false;
+        }
+        return a.equals(b);
+    }
+
+    @Override
+    public int hashCode(Object o) {
+        if (o == null) {
+            return 0;
+        }
+        return o.hashCode();
+    }
+
+    @Override
+    public Serializable disassemble(Object value, SessionImplementor session) {
+        return (Serializable) value;
+    }
+
+    @Override
+    public Object assemble(Serializable cached, SessionImplementor session, Object owner) {
+        return cached;
+    }
+
+}

--- a/optashift-employee-rostering-shared/pom.xml
+++ b/optashift-employee-rostering-shared/pom.xml
@@ -25,6 +25,13 @@
       <artifactId>gwt-jackson-rest-processor</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- Hibernate -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <!-- Used at compile time by OffsetDateTimeHibernateType -->
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/employee/EmployeeAvailability.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/employee/EmployeeAvailability.java
@@ -19,6 +19,7 @@ package org.optaplanner.openshift.employeerostering.shared.employee;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
@@ -29,6 +30,9 @@ import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.annotations.Columns;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 import org.optaplanner.openshift.employeerostering.shared.common.AbstractPersistable;
 import org.optaplanner.openshift.employeerostering.shared.employee.view.EmployeeAvailabilityView;
 
@@ -62,8 +66,12 @@ public class EmployeeAvailability extends AbstractPersistable {
     @ManyToOne(fetch = FetchType.EAGER)
     private Employee employee;
 
+    @Type(type = "org.optaplanner.openshift.employeerostering.server.common.jpa.OffsetDateTimeHibernateType")
+    @Columns(columns = {@Column(name = "startDateTime"), @Column(name="startDateTimeOffset")})
     @NotNull
     private OffsetDateTime startDateTime;
+    @Type(type = "org.optaplanner.openshift.employeerostering.server.common.jpa.OffsetDateTimeHibernateType")
+    @Columns(columns = {@Column(name = "endDateTime"), @Column(name="endDateTimeOffset")})
     @NotNull
     private OffsetDateTime endDateTime;
 

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/Shift.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/Shift.java
@@ -18,12 +18,15 @@ package org.optaplanner.openshift.employeerostering.shared.shift;
 
 import java.time.OffsetDateTime;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.annotations.Columns;
+import org.hibernate.annotations.Type;
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.domain.entity.PlanningPin;
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
@@ -80,8 +83,12 @@ public class Shift extends AbstractPersistable {
     @ManyToOne
     private Spot spot;
 
+    @Type(type = "org.optaplanner.openshift.employeerostering.server.common.jpa.OffsetDateTimeHibernateType")
+    @Columns(columns = {@Column(name = "startDateTime"), @Column(name="startDateTimeOffset")})
     @NotNull
     private OffsetDateTime startDateTime;
+    @Type(type = "org.optaplanner.openshift.employeerostering.server.common.jpa.OffsetDateTimeHibernateType")
+    @Columns(columns = {@Column(name = "endDateTime"), @Column(name="endDateTimeOffset")})
     @NotNull
     private OffsetDateTime endDateTime;
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <version.javax.javaee-api>7.0</version.javax.javaee-api>
     <version.net.ltgt.gwt.maven.gwt-maven-plugin>1.0-rc-9</version.net.ltgt.gwt.maven.gwt-maven-plugin>
     <version.org.gwtbootstrap3>0.9.4</version.org.gwtbootstrap3>
+    <version.org.hibernate>5.1.10.Final</version.org.hibernate>
     <version.org.jboss.errai>4.1.2.Final</version.org.jboss.errai>
     <version.org.jboss.resteasy>3.1.4.Final</version.org.jboss.resteasy>
     <version.org.optaplanner>${project.version}</version.org.optaplanner>
@@ -144,6 +145,11 @@
         <groupId>javax</groupId>
         <artifactId>javaee-api</artifactId>
         <version>${version.javax.javaee-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-core</artifactId>
+        <version>${version.org.hibernate}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Fails with

```
15:32:25,210 ERROR [org.hibernate.internal.SessionFactoryImpl] (ServerService Thread Pool -- 5) HHH000177: Error in named query: Shift.filter: org.hibernate.hql.internal.ast.QuerySyntaxException: >= operator not supported on composite types. [select distinct sa from org.optaplanner.openshift.employeerostering.shared.shift.Shift sa left join fetch sa.spot s left join fetch sa.rotationEmployee re left join fetch sa.employee e where sa.tenantId = :tenantId and sa.endDateTime >= :startDateTime and sa.startDateTime < :endDateTime order by sa.startDateTime, s.name, e.name]
	at ...
Caused by: org.hibernate.hql.internal.ast.QuerySyntaxException: >= operator not supported on composite types.
         at ...
```


See https://stackoverflow.com/questions/50132548/hibernate-compositeusertype-that-is-comparible-in-jpa-ql-or-hql-query