### PR TITLE
Fixed SpotPopoverForm

### DIFF
--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/common/LocalDateTimePicker.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/common/LocalDateTimePicker.java
@@ -1,0 +1,60 @@
+package org.optaplanner.openshift.employeerostering.gwtui.client.common;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
+import javax.inject.Inject;
+import javax.validation.ValidationException;
+
+import com.google.gwt.user.client.TakesValue;
+import elemental2.core.Date;
+import elemental2.dom.HTMLInputElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.optaplanner.openshift.employeerostering.shared.common.GwtJavaTimeWorkaroundUtil;
+
+@Templated
+public class LocalDateTimePicker implements TakesValue<LocalDateTime> {
+
+    @Inject
+    @DataField("date-picker")
+    private HTMLInputElement datePicker;
+
+    @Inject
+    @DataField("time-picker")
+    private HTMLInputElement timePicker;
+
+    @Override
+    public void setValue(LocalDateTime value) {
+        datePicker.valueAsDate = new Date(Date.parse(value.toLocalDate().toString()));
+        timePicker.value = value.toLocalTime().toString();
+    }
+
+    @Override
+    public LocalDateTime getValue() {
+        Date date;
+        datePicker.checkValidity();
+        timePicker.checkValidity();
+        if (datePicker.validity.valid && timePicker.validity.valid) {
+            try {
+                date = datePicker.valueAsDate;
+            } catch (Exception e) {
+                // Browser does not support input type date/time; need to convert String to Date
+                date = new Date(Date.parse(datePicker.value));
+            }
+            LocalTime localTime = LocalTime.parse(timePicker.value);
+            LocalDate localDate = GwtJavaTimeWorkaroundUtil.toLocalDate(OffsetDateTime.parse(date.toISOString()));
+            return localDate.atTime(localTime);
+        } else {
+            datePicker.reportValidity();
+            timePicker.reportValidity();
+            if (!datePicker.validity.valid) {
+                throw new ValidationException(datePicker.validationMessage);
+            } else {
+                throw new ValidationException(timePicker.validationMessage);
+            }
+        }
+    }
+}

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/common/LocalDateTimePicker.css
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/common/LocalDateTimePicker.css
@@ -1,0 +1,4 @@
+.local-date-time-picker {
+	display: inline-grid;
+	grid-template-columns: 2fr 1fr;
+}

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/common/LocalDateTimePicker.html
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/common/LocalDateTimePicker.html
@@ -1,0 +1,9 @@
+<div class="local-date-time-picker">
+  <!-- Ideally by the year 9999 all browser support input type date so we don't need pattern -->
+  <!-- TODO: Load pattern from i18n (pattern is ignored by browser, so no way to set
+       date format on browsers that do support input type date) -->
+  <input class="form-control" data-field="date-picker" type="date"
+  pattern="(0[1-9]|1[0-9]|2[0-9]|3[01])/(0[1-9]|1[012])/[0-9]{4}" required></input>
+  <input class="form-control" data-field="time-picker" type="time"
+  pattern="[012]?[0-9]:[012345][0-9]" required></input>
+</div>

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/ShiftBlobPopoverContent.html
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/ShiftBlobPopoverContent.html
@@ -31,22 +31,14 @@
                 <div class="row form-group">
                     <div class="col-md-6">
                         <label>From</label>
-                        <input class="form-control" type="text" data-field="from-day" disabled>
-                    </div>
-                    <div class="col-md-6">
-                        <label>&nbsp;</label>
-                        <input class="form-control" type="text" data-field="from-hour" disabled>
+                        <div data-field="from"></div>
                     </div>
                 </div>
 
                 <div class="row form-group">
                     <div class="col-md-6">
                         <label>To</label>
-                        <input class="form-control" type="text" data-field="to-day" disabled>
-                    </div>
-                    <div class="col-md-6">
-                        <label>&nbsp;</label>
-                        <input class="form-control" type="text" data-field="to-hour" disabled>
+                        <div data-field="to"></div>
                     </div>
                 </div>
 
@@ -71,13 +63,6 @@
                                 <input data-field="pinned" type="checkbox"> Pinned
                             </label>
                         </div>
-                    </div>
-                </div>
-
-                <div class="form-group row">
-                    <div class="col-md-12">
-                        <label>Rotation employee</label>
-                        <p class="form-control-static" data-field="rotation-employee"></p>
                     </div>
                 </div>
 

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/common/GwtJavaTimeWorkaroundUtil.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/common/GwtJavaTimeWorkaroundUtil.java
@@ -70,4 +70,5 @@ public class GwtJavaTimeWorkaroundUtil {
     public static int getOffsetInMinutes(LocalDate date, ZoneOffset offset) {
         return (offset.getTotalSeconds() / 60) - JsDate.create(date.getYear(), date.getMonthValue(), date.getDayOfMonth()).getTimezoneOffset();
     }
+
 }


### PR DESCRIPTION
-Created a widget that uses `input[date] + input[time]` to be a `LocalDateTime` Widget (in theory, should fall-back to text input okay)
-Removed RotationEmployee from SpotPopoverForm
-Allow setting the Employee if the shift is not pinned