### PR TITLE
Use single click to add shifts; fixed delete in popup

### DIFF
--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/employeeroster/EmployeeRosterViewport.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/employeeroster/EmployeeRosterViewport.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import org.jboss.errai.common.client.api.elemental2.IsElement;
+import org.optaplanner.openshift.employeerostering.gwtui.client.common.FailureShownRestCallback;
 import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.grid.CssGridLines;
 import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.grid.Ticks;
 import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.model.Blob;
@@ -41,6 +42,7 @@ import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.view.
 import org.optaplanner.openshift.employeerostering.shared.common.GwtJavaTimeWorkaroundUtil;
 import org.optaplanner.openshift.employeerostering.shared.employee.Employee;
 import org.optaplanner.openshift.employeerostering.shared.employee.EmployeeAvailabilityState;
+import org.optaplanner.openshift.employeerostering.shared.employee.EmployeeRestServiceBuilder;
 import org.optaplanner.openshift.employeerostering.shared.employee.view.EmployeeAvailabilityView;
 import org.optaplanner.openshift.employeerostering.shared.roster.RosterState;
 import org.optaplanner.openshift.employeerostering.shared.spot.Spot;
@@ -123,6 +125,11 @@ public class EmployeeRosterViewport extends Viewport<LocalDateTime> {
         LocalDateTime startOfDay = start.toLocalDate().atTime(LocalTime.of(0, 0));
         final EmployeeAvailabilityView employeeAvailabilityView = new EmployeeAvailabilityView(tenantId, employeeLane.getEmployee(),
                 startOfDay, startOfDay.plusDays(1), EmployeeAvailabilityState.UNAVAILABLE);
+
+        EmployeeRestServiceBuilder.addEmployeeAvailability(tenantId, employeeAvailabilityView,
+                FailureShownRestCallback.onSuccess((id) -> {
+                    employeeAvailabilityView.setId(id);
+                }));
 
         return Stream.of(new EmployeeBlob(scale, spotIdToSpotMap, employeeIdToEmployeeMap, employeeAvailabilityView));
     }

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/ShiftBlobPopoverContent.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/ShiftBlobPopoverContent.java
@@ -182,8 +182,13 @@ public class ShiftBlobPopoverContent implements BlobPopoverContent {
 
     @EventHandler("delete-button")
     public void onDeleteButtonClick(@ForEvent("click") final MouseEvent e) {
-        blobView.remove();
-        popover.hide();
+        final ShiftBlob blob = (ShiftBlob) blobView.getBlob();
+        final ShiftView shiftView = blob.getShiftView();
+
+        ShiftRestServiceBuilder.removeShift(shiftView.getTenantId(), shiftView.getId(), onSuccess(v -> {
+            blobView.remove();
+            popover.hide();
+        }));
         e.stopPropagation();
     }
 

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/SpotRosterViewport.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/pages/spotroster/SpotRosterViewport.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import org.jboss.errai.common.client.api.elemental2.IsElement;
+import org.optaplanner.openshift.employeerostering.gwtui.client.common.FailureShownRestCallback;
 import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.grid.CssGridLines;
 import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.grid.Ticks;
 import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.model.Blob;
@@ -41,6 +42,7 @@ import org.optaplanner.openshift.employeerostering.gwtui.client.rostergrid.view.
 import org.optaplanner.openshift.employeerostering.shared.common.GwtJavaTimeWorkaroundUtil;
 import org.optaplanner.openshift.employeerostering.shared.employee.Employee;
 import org.optaplanner.openshift.employeerostering.shared.roster.RosterState;
+import org.optaplanner.openshift.employeerostering.shared.shift.ShiftRestServiceBuilder;
 import org.optaplanner.openshift.employeerostering.shared.shift.view.ShiftView;
 import org.optaplanner.openshift.employeerostering.shared.spot.Spot;
 
@@ -101,6 +103,11 @@ public class SpotRosterViewport extends Viewport<LocalDateTime> {
         final SpotLane spotLane = (SpotLane) lane;
 
         final ShiftView shift = new ShiftView(tenantId, spotLane.getSpot(), start, start.plusHours(8L));
+
+        ShiftRestServiceBuilder.addShift(tenantId, shift,
+                FailureShownRestCallback.onSuccess((id) -> {
+                    shift.setId(id);
+                }));
 
         return Stream.of(new ShiftBlob(scale, spotIdToSpotMap, employeeIdToEmployeeMap, shift));
     }

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/rostergrid/view/SubLaneView.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/rostergrid/view/SubLaneView.java
@@ -93,7 +93,7 @@ public class SubLaneView<T> implements ListElementView<SubLane<T>> {
         }
     }
 
-    private void onClick(final @ForEvent("click") MouseEvent e) {
+    private void onClick(final MouseEvent e) {
 
         if (!e.target.equals(e.currentTarget)) {
             return;


### PR DESCRIPTION
Due to `click` being fired on the end of drag events, needed to use a complicated `mousedown`, `mousemove`, `mouseup` device to check if the user clicked without dragging.