### PR TITLE
PLANNER-1097: Fixed font and spacing issues

### DIFF
--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/DateTimeViewport.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/DateTimeViewport.java
@@ -2,7 +2,6 @@ package org.optaplanner.openshift.employeerostering.gwtui.client.viewport;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -78,7 +77,7 @@ public abstract class DateTimeViewport<T, M> {
 
     protected abstract Function<LocalDateTime, String> getTimeHeaderFunction();
 
-    protected abstract Function<LocalDateTime, List<String>> getDateHeaderAdditionalClassesFunction();
+    protected abstract Function<LocalDateTime, List<String>> getDateHeaderIconClassesFunction();
 
     protected abstract String getLoadingTaskId();
 
@@ -109,7 +108,7 @@ public abstract class DateTimeViewport<T, M> {
             dateTimeHeader.generateTicks(gridObjectPlacer, scale, 0L,
                                          getDateHeaderFunction(),
                                          getTimeHeaderFunction(),
-                                         getDateHeaderAdditionalClassesFunction());
+                                         getDateHeaderIconClassesFunction());
 
             Map<Long, String> viewLanes = getLaneTitlesFor(view);
             for (Long laneId : viewLanes.keySet()) {

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/availabilityroster/AvailabilityRosterPageViewport.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/availabilityroster/AvailabilityRosterPageViewport.java
@@ -123,7 +123,7 @@ public class AvailabilityRosterPageViewport extends DateTimeViewport<Availabilit
     }
 
     @Override
-    protected Function<LocalDateTime, List<String>> getDateHeaderAdditionalClassesFunction() {
+    protected Function<LocalDateTime, List<String>> getDateHeaderIconClassesFunction() {
         return (date) -> (rosterState.isHistoric(date)) ? Collections.emptyList() : (rosterState.isPublished(date)) ? Arrays.asList("fa", "fa-check") : Arrays.asList("fa", "fa-list-alt");
     }
 

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/grid/DateSpan.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/grid/DateSpan.java
@@ -1,0 +1,31 @@
+package org.optaplanner.openshift.employeerostering.gwtui.client.viewport.grid;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import elemental2.dom.HTMLElement;
+import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+@Templated
+public class DateSpan implements IsElement {
+
+    @Inject
+    @DataField("icon")
+    @Named("span")
+    private HTMLElement icon;
+
+    @Inject
+    @DataField("date")
+    @Named("span")
+    private HTMLElement date;
+
+    public HTMLElement getIcon() {
+        return icon;
+    }
+
+    public HTMLElement getDate() {
+        return date;
+    }
+}

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/grid/DateTimeHeader.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/grid/DateTimeHeader.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import elemental2.dom.HTMLElement;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.client.local.api.elemental2.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
@@ -33,18 +34,18 @@ public class DateTimeHeader implements IsElement {
     private HTMLElement spanFactory;
 
     @Inject
+    private ManagedInstance<DateSpan> dateSpanFactory;
+
+    @Inject
     private CSSGlobalStyle cssGlobalStyle;
 
-    private HTMLElement dateTickFactory;
     private HTMLElement dateChangeTickFactory;
     private HTMLElement timeTickFactory;
 
     @PostConstruct
     public void init() {
-        dateTickFactory = (HTMLElement) spanFactory.cloneNode(false);
         dateChangeTickFactory = (HTMLElement) spanFactory.cloneNode(false);
         timeTickFactory = (HTMLElement) spanFactory.cloneNode(false);
-        dateTickFactory.classList.add("date-tick");
         dateChangeTickFactory.classList.add("date-change-tick");
         timeTickFactory.classList.add("time-tick");
     }
@@ -54,7 +55,7 @@ public class DateTimeHeader implements IsElement {
                               Long offset,
                               Function<LocalDateTime, String> dateTextSupplier,
                               Function<LocalDateTime, String> timeTextSupplier,
-                              Function<LocalDateTime, List<String>> classListSupplier) {
+                              Function<LocalDateTime, List<String>> iconClassListSupplier) {
         while (container.lastElementChild != null) {
             container.lastElementChild.remove();
         }
@@ -71,15 +72,15 @@ public class DateTimeHeader implements IsElement {
             }
 
             if (!GridObjectPlacer.isHidden(i, i, scale) && (i + offset) % dateStep == 0) {
-                HTMLElement dateTick = (HTMLElement) dateTickFactory.cloneNode(false);
+                DateSpan dateTick = dateSpanFactory.get();
                 HTMLElement dateChangeTick = (HTMLElement) dateChangeTickFactory.cloneNode(false);
                 gridObjectPlacer.setStartPositionInGridUnits(dateChangeTick, scale, i, true);
                 gridObjectPlacer.setEndPositionInGridUnits(dateChangeTick, scale, i, true);
-                gridObjectPlacer.setStartPositionInGridUnits(dateTick, scale, i, true);
-                gridObjectPlacer.setEndPositionInGridUnits(dateTick, scale, i + dateStep, true);
-                dateTick.innerHTML = dateTextSupplier.apply(scale.toScaleUnits(i + offset));
-                classListSupplier.apply(scale.toScaleUnits(i)).forEach((clazz) -> dateTick.classList.add(clazz));
-                container.appendChild(dateTick);
+                gridObjectPlacer.setStartPositionInGridUnits(dateTick.getElement(), scale, i, true);
+                gridObjectPlacer.setEndPositionInGridUnits(dateTick.getElement(), scale, i + dateStep, true);
+                dateTick.getDate().innerHTML = dateTextSupplier.apply(scale.toScaleUnits(i + offset));
+                iconClassListSupplier.apply(scale.toScaleUnits(i)).forEach(clazz -> dateTick.getIcon().classList.add(clazz));
+                container.appendChild(dateTick.getElement());
                 container.appendChild(dateChangeTick);
             }
         }

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/rotation/RotationPageViewport.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/rotation/RotationPageViewport.java
@@ -126,7 +126,7 @@ public class RotationPageViewport extends DateTimeViewport<RotationView, Rotatio
     }
 
     @Override
-    protected Function<LocalDateTime, List<String>> getDateHeaderAdditionalClassesFunction() {
+    protected Function<LocalDateTime, List<String>> getDateHeaderIconClassesFunction() {
         return (date) -> Collections.emptyList();
     }
 

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/shiftroster/ShiftRosterPageViewport.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/shiftroster/ShiftRosterPageViewport.java
@@ -119,7 +119,7 @@ public class ShiftRosterPageViewport extends DateTimeViewport<ShiftRosterView, S
     }
 
     @Override
-    protected Function<LocalDateTime, List<String>> getDateHeaderAdditionalClassesFunction() {
+    protected Function<LocalDateTime, List<String>> getDateHeaderIconClassesFunction() {
         return (date) -> (rosterState.isHistoric(date)) ? Collections.emptyList() : (rosterState.isPublished(date)) ? Arrays.asList("fa", "fa-check") : Arrays.asList("fa", "fa-list-alt");
     }
 

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/app/AppView.less
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/app/AppView.less
@@ -13,6 +13,11 @@
     left: 0;
 }
 
+.header-container {
+    padding-right: 20px;
+    margin-right: -20px;
+}
+
 .header-main {
     margin-left: -20px;
     margin-right: -20px;
@@ -25,6 +30,10 @@
     padding-right: 40px;
     margin: -20px -20px 0 -20px;
     background-color: white;
+}
+
+.navbar-container {
+    width: 100vw;
 }
 
 .footer {

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/header/HeaderView.html
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/header/HeaderView.html
@@ -19,7 +19,7 @@
 
     <nav class="header-main navbar navbar-pf" data-field="header" role="navigation">
 
-        <div class="navbar-header ">
+        <div class="navbar-header header-container">
             <a href="/index.html" class="navbar-brand" style="margin: 10px">
                 <img class="kie-brand-icon" src="app/optaPlannerLogo200px.png" alt="Optaplanner Employee Rostering" height="33" width="200">
             </a>

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/header/MenuView.html
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/header/MenuView.html
@@ -1,4 +1,4 @@
-<ul class="nav navbar-nav navbar-primary">
+<ul class="nav navbar-nav navbar-primary navbar-container">
     <li>
         <a data-field="skills" href="#" data-i18n-key="Menu.Skills"></a>
     </li>

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/grid/DateSpan.html
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/grid/DateSpan.html
@@ -1,0 +1,4 @@
+<span class="date-tick">
+    <span data-field="icon"></span>
+    <span data-field="date"></span>
+</span>

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/public/viewport.less
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/public/viewport.less
@@ -37,6 +37,7 @@
     display: inline;
     position: sticky;
     left: 0;
+    padding-left: 10px;
     background-color: white;
     border: 1px solid black;
     border-top: none;


### PR DESCRIPTION
This PR fixes:

- Header width (now navbar extends the entire screen, instead of stopping 20px before)

- Icon spacing on dates

- Added left margin to spot/employee names in roster screens

- Fixed Date Font