### PR TITLE
Overconstrained planning

### DIFF
--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/gwtjackson/HardMediumSoftLongScoreJsonDeserializer.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/gwtjackson/HardMediumSoftLongScoreJsonDeserializer.java
@@ -6,15 +6,16 @@ import com.github.nmorel.gwtjackson.client.JsonDeserializationContext;
 import com.github.nmorel.gwtjackson.client.JsonDeserializer;
 import com.github.nmorel.gwtjackson.client.JsonDeserializerParameters;
 import com.github.nmorel.gwtjackson.client.stream.JsonReader;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 
 // TODO fix https://github.com/nmorel/gwt-jackson/issues/113 or move into upstream module org.optaplanner:optaplanner-gwtjackson
-public class HardSoftScoreJsonDeserializer extends JsonDeserializer<HardSoftScore> {
+public class HardMediumSoftLongScoreJsonDeserializer extends JsonDeserializer<HardMediumSoftLongScore> {
 
     @Override
-    protected HardSoftScore doDeserialize(JsonReader reader, JsonDeserializationContext ctx, JsonDeserializerParameters params) {
+    protected HardMediumSoftLongScore doDeserialize(JsonReader reader, JsonDeserializationContext ctx, JsonDeserializerParameters params) {
         String text = reader.nextString();
-        return HardSoftScore.parseScore(text);
+        return HardMediumSoftLongScore.parseScore(text);
     }
 
 }

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/gwtjackson/HardMediumSoftLongScoreJsonSerializer.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/gwtjackson/HardMediumSoftLongScoreJsonSerializer.java
@@ -4,13 +4,14 @@ import com.github.nmorel.gwtjackson.client.JsonSerializationContext;
 import com.github.nmorel.gwtjackson.client.JsonSerializer;
 import com.github.nmorel.gwtjackson.client.JsonSerializerParameters;
 import com.github.nmorel.gwtjackson.client.stream.JsonWriter;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 
 // TODO fix https://github.com/nmorel/gwt-jackson/issues/113 or move into upstream module org.optaplanner:optaplanner-gwtjackson
-public class HardSoftScoreJsonSerializer extends JsonSerializer<HardSoftScore> {
+public class HardMediumSoftLongScoreJsonSerializer extends JsonSerializer<HardMediumSoftLongScore> {
 
     @Override
-    protected void doSerialize(JsonWriter writer, HardSoftScore value, JsonSerializationContext ctx, JsonSerializerParameters params) {
+    protected void doSerialize(JsonWriter writer, HardMediumSoftLongScore value, JsonSerializationContext ctx, JsonSerializerParameters params) {
         writer.value(value.toString());
     }
 

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/RosterToolbar.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/RosterToolbar.java
@@ -14,6 +14,7 @@ import elemental2.dom.MouseEvent;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.ForEvent;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.openshift.employeerostering.gwtui.client.common.EventManager;
 import org.optaplanner.openshift.employeerostering.gwtui.client.common.EventManager.Event;
@@ -115,11 +116,12 @@ public abstract class RosterToolbar {
             }
         };
         eventManager.subscribeToEvent(getViewRefreshEvent(), (view) -> {
-            final Optional<HardSoftScore> score = Optional.ofNullable(view.getScore());
+            final Optional<HardMediumSoftLongScore> score = Optional.ofNullable(view.getScore());
 
             if (score.isPresent()) {
                 scores.classList.remove("hidden");
                 hardScore.textContent = score.get().getHardScore() + "";
+                // TODO show medium score
                 softScore.textContent = score.get().getSoftScore() + "";
             } else {
                 scores.classList.add("hidden");

--- a/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/rebind/OptaShiftRosteringGwtJacksonConfiguration.java
+++ b/optashift-employee-rostering-gwtui/src/main/java/org/optaplanner/openshift/employeerostering/gwtui/rebind/OptaShiftRosteringGwtJacksonConfiguration.java
@@ -9,11 +9,11 @@ import java.time.OffsetTime;
 import java.time.ZoneId;
 
 import com.github.nmorel.gwtjackson.client.AbstractConfiguration;
-import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.DurationJsonDeserializer;
 import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.DurationJsonSerializer;
-import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.HardSoftScoreJsonDeserializer;
-import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.HardSoftScoreJsonSerializer;
+import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.HardMediumSoftLongScoreJsonDeserializer;
+import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.HardMediumSoftLongScoreJsonSerializer;
 import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.LocalDateJsonDeserializer;
 import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.LocalDateJsonSerializer;
 import org.optaplanner.openshift.employeerostering.gwtui.client.gwtjackson.LocalDateTimeJsonDeserializer;
@@ -34,7 +34,7 @@ public class OptaShiftRosteringGwtJacksonConfiguration extends AbstractConfigura
         type(LocalDate.class).serializer(LocalDateJsonSerializer.class).deserializer(LocalDateJsonDeserializer.class);
         type(LocalDateTime.class).serializer(LocalDateTimeJsonSerializer.class).deserializer(LocalDateTimeJsonDeserializer.class);
         type(LocalTime.class).serializer(LocalTimeJsonSerializer.class).deserializer(LocalTimeJsonDeserializer.class);
-        type(HardSoftScore.class).serializer(HardSoftScoreJsonSerializer.class).deserializer(HardSoftScoreJsonDeserializer.class);
+        type(HardMediumSoftLongScore.class).serializer(HardMediumSoftLongScoreJsonSerializer.class).deserializer(HardMediumSoftLongScoreJsonDeserializer.class);
         type(ZoneId.class).serializer(ZoneIdJsonSerializer.class).deserializer(ZoneIdJsonDeserializer.class);
         type(OffsetDateTime.class).serializer(OffsetDateTimeJsonSerializer.class).deserializer(OffsetDateTimeJsonDeserializer.class);
         type(OffsetTime.class).serializer(OffsetTimeJsonSerializer.class).deserializer(OffsetTimeJsonDeserializer.class);

--- a/optashift-employee-rostering-server/src/main/resources/org/optaplanner/openshift/employeerostering/server/solver/employeeRosteringScoreRules.drl
+++ b/optashift-employee-rostering-server/src/main/resources/org/optaplanner/openshift/employeerostering/server/solver/employeeRosteringScoreRules.drl
@@ -19,7 +19,7 @@ package org.optaplanner.openshift.employeerostering.server.solver;
 
 import java.time.temporal.ChronoUnit;
 
-import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScoreHolder;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreHolder;
 import org.optaplanner.openshift.employeerostering.shared.employee.Employee;
 import org.optaplanner.openshift.employeerostering.shared.employee.EmployeeAvailability;
 import org.optaplanner.openshift.employeerostering.shared.employee.EmployeeAvailabilityState;
@@ -30,7 +30,7 @@ import org.optaplanner.openshift.employeerostering.shared.spot.Spot;
 import org.optaplanner.openshift.employeerostering.shared.tenant.TenantConfiguration;
 import org.optaplanner.openshift.employeerostering.shared.common.GwtJavaTimeWorkaroundUtil;
 
-global HardSoftScoreHolder scoreHolder;
+global HardMediumSoftLongScoreHolder scoreHolder;
 
 // ############################################################################
 // Hard constraints
@@ -88,6 +88,18 @@ rule "No 2 shifts within 10 hours from each other"
     then
         scoreHolder.addHardConstraintMatch(kcontext, -1);
 end
+
+// ############################################################################
+// Medium constraints
+// ############################################################################
+
+rule "Assign every shift"
+    when
+        Shift(employee == null)
+    then
+        scoreHolder.addMediumConstraintMatch(kcontext, -1);
+end
+
 
 // ############################################################################
 // Soft constraints

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/roster/Roster.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/roster/Roster.java
@@ -24,6 +24,7 @@ import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.drools.ProblemFactProperty;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.openshift.employeerostering.shared.common.AbstractPersistable;
 import org.optaplanner.openshift.employeerostering.shared.employee.Employee;
@@ -55,7 +56,7 @@ public class Roster extends AbstractPersistable {
     private List<Shift> shiftList;
 
     @PlanningScore
-    private HardSoftScore score = null;
+    private HardMediumSoftLongScore score = null;
 
     @SuppressWarnings("unused")
     public Roster() {}
@@ -132,11 +133,11 @@ public class Roster extends AbstractPersistable {
         this.shiftList = shiftList;
     }
 
-    public HardSoftScore getScore() {
+    public HardMediumSoftLongScore getScore() {
         return score;
     }
 
-    public void setScore(HardSoftScore score) {
+    public void setScore(HardMediumSoftLongScore score) {
         this.score = score;
     }
 

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/roster/view/AbstractRosterView.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/roster/view/AbstractRosterView.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScore;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.openshift.employeerostering.shared.employee.Employee;
 import org.optaplanner.openshift.employeerostering.shared.roster.RosterState;
@@ -26,7 +27,7 @@ public class AbstractRosterView implements Serializable {
     @NotNull
     protected RosterState rosterState;
 
-    private HardSoftScore score = null;
+    private HardMediumSoftLongScore score = null;
 
     @Override
     public String toString() {
@@ -77,11 +78,11 @@ public class AbstractRosterView implements Serializable {
         this.employeeList = employeeList;
     }
 
-    public HardSoftScore getScore() {
+    public HardMediumSoftLongScore getScore() {
         return score;
     }
 
-    public void setScore(HardSoftScore score) {
+    public void setScore(HardMediumSoftLongScore score) {
         this.score = score;
     }
 

--- a/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/Shift.java
+++ b/optashift-employee-rostering-shared/src/main/java/org/optaplanner/openshift/employeerostering/shared/shift/Shift.java
@@ -90,7 +90,7 @@ public class Shift extends AbstractPersistable {
     private boolean pinnedByUser = false;
 
     @ManyToOne
-    @PlanningVariable(valueRangeProviderRefs = "employeeRange")
+    @PlanningVariable(valueRangeProviderRefs = "employeeRange", nullable = true)
     private Employee employee = null;
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
To try it out:
- open a dataset, solve it and notice that all shifts get assigned
- now pick a date and start adding new shifts for a spot there. Add so many shifts, that there are more shifts on that date then there are employees. Click solve. Notice that it still finds a schedule with no hard constraints broken, but now there are medium constraints broken: a few shifts didn't get assigned.

@Christopher-Chianelli Can you visualize the medium score in the UI too? And the indictement work will make the unassigned shifts stick out like a soar thumb, of course.