### PR TITLE
PLANNER-1065: Made Employee Availability editing more steamlined

### DIFF
--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/availabilityroster/AvailabilityGridObject.css
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/availabilityroster/AvailabilityGridObject.css
@@ -1,0 +1,16 @@
+.timeslot-availability {
+    float: left;
+    margin-right: 5px;
+}
+
+.active.timeslot-unavailable span {
+    color: red !important;
+}
+
+.active.timeslot-undesired span {
+    color: orange !important;
+}
+
+.active.timeslot-desired span {
+    color: green !important;
+}

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/availabilityroster/AvailabilityGridObject.html
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/client/viewport/availabilityroster/AvailabilityGridObject.html
@@ -1,3 +1,19 @@
-<span class="spanning-blob" data-field="root">
-    <span data-field="label"></span>
+<span class="spanning-blob" style="display: inline-grid; grid-template-columns: 1fr 90px;" data-field="root">
+    <span data-field="label" style="grid-column: 1;"></span>
+    <span class="show-on-hover" style="grid-column: 2; grid-template-columns: 1fr 15px; grid-template-rows: 10px 1fr 30px;">
+        <button data-field="delete" style="color: black; margin-top: -10px; grid-column: 2; grid-row: 1;" class="btn btn-link">
+            <span class="pficon pficon-close"></span>
+        </button>
+        <span style="grid-row: 3;" class="btn-group timeslot-availability-buttons" role="group" aria-label="availability">
+            <button data-field="timeslot-unavailable" class="btn btn-xs btn-default timeslot-unavailable" aria-label="Unavailable">
+                <span class="glyphicon glyphicon-ban-circle" aria-hidden="true"></span>
+            </button>
+            <button data-field="timeslot-undesired" class="btn btn-xs btn-default timeslot-undesired" aria-label="Undesired">
+                <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
+            </button>
+            <button data-field="timeslot-desired" class="btn btn-xs btn-default timeslot-desired" aria-label="Desired">
+                <span class="glyphicon glyphicon glyphicon-ok-circle" aria-hidden="true"></span>
+            </button>
+        </span>
+    </span>
 </span>

--- a/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/public/viewport.less
+++ b/optashift-employee-rostering-gwtui/src/main/resources/org/optaplanner/openshift/employeerostering/gwtui/public/viewport.less
@@ -116,6 +116,17 @@
     border: 1px dashed black;
 }
 
+.show-on-hover {
+    display: none;
+}
+
+*:not(.selected):hover > .show-on-hover {
+    display: grid;
+}
+
+*:not(.selected) > .show-on-hover:hover {
+    display: grid;
+}
 
 .pinned:before {
 	font-family: FontAwesome;


### PR DESCRIPTION
Allow people to change the availability type via "traffic lights" at the bottom and delete it by clicking the "X" in the top right corner